### PR TITLE
Fixes a regression in the output of the command RequestInformation introduced between release 2.4.11 and 2.4.17

### DIFF
--- a/src/main/java/org/waarp/openr66/client/RequestInformation.java
+++ b/src/main/java/org/waarp/openr66/client/RequestInformation.java
@@ -241,7 +241,7 @@ public class RequestInformation implements Runnable {
 				value = 0;
 				R66Result r66result = result.getResult();
 				ValidPacket info = (ValidPacket) r66result.other;
-				logger.warn(Messages.getString("RequestInformation.Success") + info.getSmiddle() + "     " + info.getSheader()); //$NON-NLS-1$
+				logger.warn(Messages.getString("RequestInformation.Success") + "\n" + info.getSmiddle() + "\n" + info.getSheader()); //$NON-NLS-1$
 			} else {
 				value = 2;
 				logger.error(Messages.getString("RequestInformation.Failure") + //$NON-NLS-1$


### PR DESCRIPTION
The output was : 

  SUCCESS/FAILURE
  NB_FILE
  file1
  file2
  file3

with each component on the same line. it is now 

  SUCCESS/FAILURE    NB_FILE    file1
  file2
  file3

which breaks numerous scripts.
