### PR TITLE
2.4.26 major fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>WaarpR66</artifactId>
   <name>Waarp OpenR66</name>
-  <version>2.4.25</version>
+  <version>2.4.26</version>
   <description>
   OpenR66 is a File Transfer Monitor to be used in real production to transfer files between servers.
   It allows to start/restart a transfer, check the remote MD5, check status, make pre or post
@@ -49,7 +49,7 @@
     <dependency>
       <groupId>Waarp</groupId>
       <artifactId>WaarpCommon</artifactId>
-      <version>1.2.22</version>
+      <version>1.2.23</version>
       <exclusions>
       	<exclusion>
       		<artifactId>xml-apis</artifactId>

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -5,6 +5,16 @@
 		<author email="waarp1 at free.fr">Frederic Bregier</author>
 	</properties>
 	<body>
+        <release version="2.4.26" date="2014-03-15" description="Fix release">
+            <action dev="Frederic Bregier" type="fix">Fix DbTaskRunner LRU cache</action>
+            <action dev="Frederic Bregier" type="add">Add option -Dopenr66.cache.limit and -Dopenr66.cache.timelimit</action>
+            <action dev="Frederic Bregier" type="fix">Improve Log in SpooledDirectory</action>
+            <action dev="Frederic Bregier" type="fix">Improve Directory and File implementation</action>
+            <action dev="Frederic Bregier" type="fix">Improve Shutdown for SpooledDirectory</action>
+            <action dev="Frederic Bregier" type="add">Add programmatic support of equivalent of -Dfile.encoding=UTF-8</action>
+            <action dev="Frederic Bregier" type="add">Use LongUuid support for SpecialId when no database is used</action>
+            <action dev="Frederic Bregier" type="fix">Improve LRU cache usage, lock and preventing deadlock in NetworkTransaction</action>
+        </release>
         <release version="2.4.25" date="2014-03-01" description="Fix release">
             <action dev="Frederic Bregier" type="fix">Fix exception handling and future handling in SpooledDirectoryTransfer</action>
             <action dev="Frederic Bregier" type="fix">Improve logging in SpooledDirectory and LocalClientHandler</action>

--- a/src/main/example/Linux/ENV_R66
+++ b/src/main/example/Linux/ENV_R66
@@ -18,10 +18,10 @@ export R66BIN="${R66HOME}/lib"
 LOGSERVER=" -Dlogback.configurationFile=${R66HOME}/conf/logback.xml "
 LOGCLIENT=" -Dlogback.configurationFile=${R66HOME}/conf/logback-client.xml "
 
-R66_CLASSPATH=" ${R66BIN}/WaarpR66-2.4.25.jar:${R66BIN}/* "
+R66_CLASSPATH=" ${R66BIN}/WaarpR66-2.4.26.jar:${R66BIN}/* "
 
-export JAVARUNCLIENT="${JAVA_RUN} -cp ${R66_CLASSPATH} ${LOGCLIENT} -Dopenr66.locale=en "
-export JAVARUNSERVER="${JAVA_RUN} -cp ${R66_CLASSPATH} ${LOGSERVER} -Dopenr66.locale=en "
+export JAVARUNCLIENT="${JAVA_RUN} -cp ${R66_CLASSPATH} ${LOGCLIENT} -Dopenr66.locale=en -Dfile.encoding=UTF-8 "
+export JAVARUNSERVER="${JAVA_RUN} -cp ${R66_CLASSPATH} ${LOGSERVER} -Dopenr66.locale=en -Dfile.encoding=UTF-8 "
 
 export SERVER_CONFIG="${R66HOME}/conf/config-serverA.xml"
 export CLIENT_CONFIG="${R66HOME}/conf/config-clientA.xml"

--- a/src/main/example/Unix/AIX/ENV_R66
+++ b/src/main/example/Unix/AIX/ENV_R66
@@ -25,10 +25,10 @@ export R66BIN="${R66HOME}/lib"
 
 # command for Client
 # Logger
-LOGSERVER=" -Dlogback.configurationFile=${R66HOME}/conf/logback.xml -Dopenr66.locale=en "
-LOGCLIENT=" -Dlogback.configurationFile=${R66HOME}/conf/logback-client.xml -Dopenr66.locale=en "
+LOGSERVER=" -Dlogback.configurationFile=${R66HOME}/conf/logback.xml -Dopenr66.locale=en -Dfile.encoding=UTF-8 "
+LOGCLIENT=" -Dlogback.configurationFile=${R66HOME}/conf/logback-client.xml -Dopenr66.locale=en -Dfile.encoding=UTF-8 "
 
-R66_CLASSPATH=" ${R66BIN}/WaarpR66-2.4.25.jar:${R66BIN}/* "
+R66_CLASSPATH=" ${R66BIN}/WaarpR66-2.4.26.jar:${R66BIN}/* "
 
 export JAVARUNCLIENT="${JAVA_RUN} -cp ${R66_CLASSPATH} ${LOGCLIENT} "
 export JAVARUNSERVER="${JAVA_RUN} -cp ${R66_CLASSPATH} ${LOGSERVER} "

--- a/src/main/example/Windows/bin/setvari.bat
+++ b/src/main/example/Windows/bin/setvari.bat
@@ -14,10 +14,10 @@ REM Logger
 SET LOGSERVER=" -Dlogback.configurationFile=%R66HOME%\conf\logback.xml "
 SET LOGCLIENT=" -Dlogback.configurationFile=%R66HOME%\conf\logback-client.xml "
 
-SET R66_CLASSPATH=" %R66BIN%\WaarpR66-2.4.25.jar;%R66BIN%\* "
+SET R66_CLASSPATH=" %R66BIN%\WaarpR66-2.4.26.jar;%R66BIN%\* "
 
-SET JAVARUNCLIENT=%JAVA_RUN% -cp %R66_CLASSPATH% %LOGCLIENT% -Dopenr66.locale=en 
-SET JAVARUNSERVER=%JAVASERVER_RUN% -cp %R66_CLASSPATH% %LOGSERVER% -Dopenr66.locale=en 
+SET JAVARUNCLIENT=%JAVA_RUN% -cp %R66_CLASSPATH% %LOGCLIENT% -Dopenr66.locale=en -Dfile.encoding=UTF-8 
+SET JAVARUNSERVER=%JAVASERVER_RUN% -cp %R66_CLASSPATH% %LOGSERVER% -Dopenr66.locale=en -Dfile.encoding=UTF-8 
 
 SET SERVER_CONFIG="%R66HOME%/conf/config-serverA.xml"
 SET CLIENT_CONFIG="%R66HOME%/conf/config-clientA.xml"

--- a/src/main/java/messages.properties
+++ b/src/main/java/messages.properties
@@ -261,7 +261,7 @@ HttpSslHandler.3                      = \ aborted since Transfer is not \
         found</b>
 HttpSslHandler.30                     = <p><center><b>Cannot delete a Rule: 
 HttpSslHandler.31                     = <p><center><b>Deleted Rule: 
-HttpSslHandler.32                     = -Rule are exported.<br>
+HttpSslHandler.32                     = -Rules are exported.<br>
 HttpSslHandler.33                     = -Authent are exported.<br>
 HttpSslHandler.34                     = New request will be blocked
 HttpSslHandler.35                     = New request will be allowed
@@ -277,6 +277,9 @@ HttpSslHandler.42                     = Configuration cannot be Saved due to \
         Format error
 HttpSslHandler.43                     = Configuration cannot be Saved due to \
         Database error
+HttpSslHandler.44                     = -Business are exported.<br>
+HttpSslHandler.45                     = -Alias are exported.<br>
+HttpSslHandler.46                     = -Roles are exported.<br>
 HttpSslHandler.5                      = \ transmitted
 HttpSslHandler.7                      = Export unsuccessful since no record \
         were found

--- a/src/main/java/messages_en.properties
+++ b/src/main/java/messages_en.properties
@@ -261,7 +261,7 @@ HttpSslHandler.3                      = \ aborted since Transfer is not \
         found</b>
 HttpSslHandler.30                     = <p><center><b>Cannot delete a Rule: 
 HttpSslHandler.31                     = <p><center><b>Deleted Rule: 
-HttpSslHandler.32                     = -Rule are exported.<br>
+HttpSslHandler.32                     = -Rules are exported.<br>
 HttpSslHandler.33                     = -Authent are exported.<br>
 HttpSslHandler.34                     = New request will be blocked
 HttpSslHandler.35                     = New request will be allowed
@@ -277,6 +277,9 @@ HttpSslHandler.42                     = Configuration cannot be Saved due to \
         Format error
 HttpSslHandler.43                     = Configuration cannot be Saved due to \
         Database error
+HttpSslHandler.44                     = -Business are exported.<br>
+HttpSslHandler.45                     = -Alias are exported.<br>
+HttpSslHandler.46                     = -Roles are exported.<br>
 HttpSslHandler.5                      = \ transmitted
 HttpSslHandler.7                      = Export unsuccessful since no record \
         were found

--- a/src/main/java/messages_fr.properties
+++ b/src/main/java/messages_fr.properties
@@ -285,7 +285,7 @@ HttpSslHandler.30                     = <p><center><b>Ne peut pas effacer une \
         Regle: 
 HttpSslHandler.31                     = <p><center><b>Effacement reussi d'une \
         Regle : 
-HttpSslHandler.32                     = -Rule sont exportees.<br>
+HttpSslHandler.32                     = -Les Regles sont exportees.<br>
 HttpSslHandler.33                     = -Authent sont exportees.<br>
 HttpSslHandler.34                     = Les nouvelles requetes seront bloquees
 HttpSslHandler.35                     = Les nouvelles requetes seront \
@@ -303,6 +303,12 @@ HttpSslHandler.42                     = La Configuration n'a pas pu etre sauve \
         en raison d'une erreur de format
 HttpSslHandler.43                     = La Configuration n'a pas pu etre sauve \
         en raison d'une erreur de base de donnees
+HttpSslHandler.44                     = -Les configurations Business sont \
+        exportees.<br>
+HttpSslHandler.45                     = -Les configurations Alias sont \
+        exportees.<br>
+HttpSslHandler.46                     = -Les configurations Roles sont \
+        exportees.<br>
 HttpSslHandler.5                      = \ transmit
 HttpSslHandler.7                      = Export en erreur car aucun \
         enregistrement n'a ete trouve

--- a/src/main/java/org/waarp/openr66/client/spooledService/SpooledEngine.java
+++ b/src/main/java/org/waarp/openr66/client/spooledService/SpooledEngine.java
@@ -35,6 +35,7 @@ import org.waarp.openr66.protocol.configuration.Configuration;
 import org.waarp.openr66.protocol.configuration.Messages;
 import org.waarp.openr66.protocol.configuration.R66SystemProperties;
 import org.waarp.openr66.protocol.utils.ChannelUtils;
+import org.waarp.openr66.protocol.utils.R66ShutdownHook;
 
 /**
  * Engine used to start and stop the SpooledDirectory service
@@ -99,6 +100,7 @@ public class SpooledEngine extends EngineAbstract {
 
 	@Override
 	public void shutdown() {
+		R66ShutdownHook.shutdownWillStart();
 		logger.info("Shutdown");
 		for (SpooledDirectoryTransfer spooled : SpooledDirectoryTransfer.list) {
 			spooled.stop();

--- a/src/main/java/org/waarp/openr66/commander/Commander.java
+++ b/src/main/java/org/waarp/openr66/commander/Commander.java
@@ -450,7 +450,7 @@ public class Commander implements CommanderInterface {
 			} finally {
 				preparedStatementRule.close();
 			}
-			if (R66ShutdownHook.isInShutdown()) {
+			if (R66ShutdownHook.isShutdownStarting()) {
 				// no more task to submit
 				return;
 			}
@@ -461,6 +461,10 @@ public class Commander implements CommanderInterface {
 				// No specific HA mode since the other servers will wait for the commit on Lock
 				preparedStatementRunner.executeQuery();
 				while (preparedStatementRunner.getNext()) {
+					if (R66ShutdownHook.isShutdownStarting()) {
+						// no more task to submit
+						return;
+					}
 					DbTaskRunner taskRunner = DbTaskRunner
 							.getFromStatement(preparedStatementRunner);
 					logger.debug("get a task: {}", taskRunner);

--- a/src/main/java/org/waarp/openr66/commander/CommanderNoDb.java
+++ b/src/main/java/org/waarp/openr66/commander/CommanderNoDb.java
@@ -181,7 +181,7 @@ public class CommanderNoDb implements CommanderInterface {
 					}
 					taskRunner = null;
 				}
-				if (R66ShutdownHook.isInShutdown()) {
+				if (R66ShutdownHook.isShutdownStarting()) {
 					// no more task to submit
 					return;
 				}

--- a/src/main/java/org/waarp/openr66/context/filesystem/R66Dir.java
+++ b/src/main/java/org/waarp/openr66/context/filesystem/R66Dir.java
@@ -205,6 +205,9 @@ public class R66Dir extends FilesystemBasedDirImpl {
 		if (session.getAuth() == null) {
 			return currentDir;
 		}
+		if (isAbsolute(currentDir)) {
+			return currentDir;
+		}
 		return ((R66Auth) session.getAuth()).getAbsolutePath(currentDir);
 	}
 

--- a/src/main/java/org/waarp/openr66/context/filesystem/R66File.java
+++ b/src/main/java/org/waarp/openr66/context/filesystem/R66File.java
@@ -283,6 +283,7 @@ public class R66File extends FilesystemBasedFileImpl {
 	public boolean canRead() throws CommandAbstractException {
 		if (isExternal) {
 			File file = new File(currentFile);
+			logger.debug("Final File: "+file+" CanRead: "+file.canRead());
 			return file.canRead();
 		}
 		return super.canRead();

--- a/src/main/java/org/waarp/openr66/protocol/configuration/Configuration.java
+++ b/src/main/java/org/waarp/openr66/protocol/configuration/Configuration.java
@@ -86,6 +86,7 @@ import org.waarp.openr66.protocol.networkhandler.packet.NetworkPacketSizeEstimat
 import org.waarp.openr66.protocol.networkhandler.ssl.NetworkSslServerPipelineFactory;
 import org.waarp.openr66.protocol.snmp.R66PrivateMib;
 import org.waarp.openr66.protocol.snmp.R66VariableFactory;
+import org.waarp.openr66.protocol.utils.ChannelUtils;
 import org.waarp.openr66.protocol.utils.R66ShutdownHook;
 import org.waarp.openr66.protocol.utils.Version;
 import org.waarp.openr66.thrift.R66ThriftServerService;
@@ -603,6 +604,12 @@ public class Configuration {
 	
 	public int maxfilenamelength = 255;
 	
+	public int timeStat = 0;
+	
+	public int limitCache = 20000;
+	
+	public long timeLimitCache = 180000;
+	
 	public Configuration() {
 		// Init signal handler
 		shutdownConfiguration.timeout = TIMEOUTCON;
@@ -611,6 +618,10 @@ public class Configuration {
 		scheduledExecutorService = Executors.newScheduledThreadPool(this.SERVER_THREAD, new WaarpThreadFactory("ScheduledTask"));
 		// Init FiniteStates
 		R66FiniteDualStates.initR66FiniteStates();
+		if (! SystemPropertyUtil.isFileEncodingCorrect()) {
+			logger.error("Issue while trying to set UTF-8 as default file encoding: use -Dfile.encoding=UTF-8 as java command argument");
+			logger.warn("Currently file.encoding is: "+ SystemPropertyUtil.get(SystemPropertyUtil.FILE_ENCODING));
+		}
 		isExecuteErrorBeforeTransferAllowed = SystemPropertyUtil.getBoolean(R66SystemProperties.OPENR66_EXECUTEBEFORETRANSFERRED, true);
 		boolean useSpaceSeparator = SystemPropertyUtil.getBoolean(R66SystemProperties.OPENR66_USESPACESEPARATOR, false);
 		if (useSpaceSeparator) {
@@ -621,6 +632,19 @@ public class Configuration {
 		chrootChecked = SystemPropertyUtil.getBoolean(R66SystemProperties.OPENR66_CHROOT_CHECKED, true);
 		blacklistBadAuthent = SystemPropertyUtil.getBoolean(R66SystemProperties.OPENR66_BLACKLIST_BADAUTHENT, true);
 		maxfilenamelength = SystemPropertyUtil.getInt(R66SystemProperties.OPENR66_FILENAME_MAXLENGTH, 255);
+		timeStat = SystemPropertyUtil.getInt(R66SystemProperties.OPENR66_TRACE_STATS, 0);
+		limitCache = SystemPropertyUtil.getInt(R66SystemProperties.OPENR66_CACHE_LIMIT, 20000);
+		if (limitCache <= 100) {
+			limitCache = 100;
+		}
+		timeLimitCache = SystemPropertyUtil.getLong(R66SystemProperties.OPENR66_CACHE_TIMELIMIT, 180000);
+		if (timeLimitCache < 1000) {
+			timeLimitCache = 1000;
+		}
+		DbTaskRunner.createLruCache(limitCache, timeLimitCache);
+		if (limitCache > 0 && timeLimitCache > 1000) {
+			launchInFixedDelay(new CleanLruCache(), timeLimitCache, TimeUnit.MILLISECONDS);
+		}
 		if (isHostProxyfied) {
 			blacklistBadAuthent = false;
 		}
@@ -690,6 +714,10 @@ public class Configuration {
 			blacklistBadAuthent = ! DbHostAuth.hasProxifiedHosts(DbConstant.admin.session);
 		}
 		shutdownConfiguration.timeout = TIMEOUTCON;
+		if (timeLimitCache < TIMEOUTCON*10) {
+			timeLimitCache = TIMEOUTCON*10;
+			DbTaskRunner.updateLruCacheTimeout(timeLimitCache);
+		}
 		R66ShutdownHook.addShutdownHook();
 		logger.debug("Use NoSSL: "+useNOSSL+" Use SSL: "+useSSL);
 		if ((!useNOSSL) && (!useSSL)) {
@@ -700,16 +728,15 @@ public class Configuration {
 		r66Startup();
 		startHttpSupport();
 		startMonitoring();
-		if (logger.isDebugEnabled()) {
-			// XXX FIXME for debug
-			launchStatistics();
-		}
+		launchStatistics();
 	}
 	/**
 	 * Used to log statistics information regularly
 	 */
 	public void launchStatistics() {
-		launchInFixedDelay(new UsageStatistic(), 10, TimeUnit.SECONDS);
+		if (timeStat > 0) {
+			launchInFixedDelay(new UsageStatistic(), timeStat, TimeUnit.SECONDS);
+		}
 	}
 	
 	public void r66Startup() throws WaarpDatabaseNoConnectionException, WaarpDatabaseSqlException {
@@ -922,6 +949,9 @@ public class Configuration {
 	 */
 	public void clientStop() {
 		WaarpSslUtility.forceCloseAllSslChannels();
+		if (! Configuration.configuration.isServer) {
+			ChannelUtils.stopLogger();
+		}
 		if (scheduledExecutorService != null) {
 			scheduledExecutorService.shutdown();
 		}
@@ -1261,5 +1291,16 @@ public class Configuration {
 			logger.warn("Issue while debugging", e);
 		}
 		return result;
+	}
+	
+	private static class CleanLruCache extends Thread {
+
+		@Override
+		public void run() {
+			int nb = DbTaskRunner.clearCache();
+			logger.info("Clear Cache: "+nb);
+			Configuration.configuration.launchInFixedDelay(this, Configuration.configuration.timeLimitCache, TimeUnit.MILLISECONDS);
+		}
+		
 	}
 }

--- a/src/main/java/org/waarp/openr66/protocol/configuration/R66SystemProperties.java
+++ b/src/main/java/org/waarp/openr66/protocol/configuration/R66SystemProperties.java
@@ -66,5 +66,19 @@ public class R66SystemProperties {
 	 * This does not prevent to change the filename after (and #ORIGINALFILENAME# does still contain the full filename, not truncated).
 	 */
 	public static final String OPENR66_FILENAME_MAXLENGTH = "openr66.filename.maxlength";
+	/**
+	 * Debug by making a trace of consumption every x s, where x is specify as value in the definition. If 0 or less, means not activated.
+	 */
+	public static final String OPENR66_TRACE_STATS = "openr66.trace.stats";
+	/**
+	 * Maximum number of DbTaskRunners to keep in LRU cache (used in self request and for instance without database).
+	 * Minimal value is 100.
+	 */
+	public static final String OPENR66_CACHE_LIMIT = "openr66.cache.limit";
+	/**
+	 * Maximum time in ms of valid element once created, used or updated (used in self request and for instance without database).
+	 * Minimal value is 1000 ms (1s). If set to 1000, the value will not be regularly deleted.
+	 */
+	public static final String OPENR66_CACHE_TIMELIMIT = "openr66.cache.timelimit";
 
 }

--- a/src/main/java/org/waarp/openr66/protocol/http/adminssl/HttpSslHandler.java
+++ b/src/main/java/org/waarp/openr66/protocol/http/adminssl/HttpSslHandler.java
@@ -68,8 +68,6 @@ import org.waarp.common.logging.WaarpInternalLoggerInterface.WaarpLevel;
 import org.waarp.common.role.RoleDefault.ROLE;
 import org.waarp.common.utility.WaarpStringUtils;
 import org.waarp.openr66.client.Message;
-import org.waarp.openr66.configuration.AuthenticationFileBasedConfiguration;
-import org.waarp.openr66.configuration.RuleFileBasedConfiguration;
 import org.waarp.openr66.context.ErrorCode;
 import org.waarp.openr66.context.R66FiniteDualStates;
 import org.waarp.openr66.context.R66Result;
@@ -87,9 +85,9 @@ import org.waarp.openr66.protocol.exception.OpenR66Exception;
 import org.waarp.openr66.protocol.exception.OpenR66ExceptionTrappedFactory;
 import org.waarp.openr66.protocol.exception.OpenR66ProtocolBusinessException;
 import org.waarp.openr66.protocol.exception.OpenR66ProtocolBusinessNoWriteBackException;
-import org.waarp.openr66.protocol.exception.OpenR66ProtocolSystemException;
 import org.waarp.openr66.protocol.http.HttpWriteCacheEnable;
 import org.waarp.openr66.protocol.localhandler.LocalChannelReference;
+import org.waarp.openr66.protocol.localhandler.ServerActions;
 import org.waarp.openr66.protocol.localhandler.packet.ErrorPacket;
 import org.waarp.openr66.protocol.localhandler.packet.RequestPacket;
 import org.waarp.openr66.protocol.localhandler.packet.RequestPacket.TRANSFERMODE;
@@ -1693,24 +1691,22 @@ public class HttpSslHandler extends SimpleChannelUpstreamHandler {
 					String directory = Configuration.configuration.baseDirectory +
 							R66Dir.SEPARATOR + Configuration.configuration.archivePath;
 					extraInformation = Messages.getString("HttpSslHandler.ExportDir") + directory + "<br>"; //$NON-NLS-1$
-					try {
-						RuleFileBasedConfiguration.writeXml(directory,
-								Configuration.configuration.HOST_ID);
-						extraInformation += Messages.getString("HttpSslHandler.32"); //$NON-NLS-1$
-					} catch (WaarpDatabaseNoConnectionException e1) {
-					} catch (WaarpDatabaseSqlException e1) {
-					} catch (OpenR66ProtocolSystemException e1) {
-					}
-					String filename =
-							directory + R66Dir.SEPARATOR + Configuration.configuration.HOST_ID +
-									"_Authentications.xml";
-					try {
-						AuthenticationFileBasedConfiguration.writeXML(Configuration.configuration,
-								filename);
+					String [] filenames = ServerActions.staticConfigExport(dbSession, directory, true, true, true, true, true);
+					// hosts, rules, business, alias, roles
+					if (filenames[0] != null) {
 						extraInformation += Messages.getString("HttpSslHandler.33"); //$NON-NLS-1$
-					} catch (WaarpDatabaseNoConnectionException e) {
-					} catch (WaarpDatabaseSqlException e) {
-					} catch (OpenR66ProtocolSystemException e) {
+					}
+					if (filenames[1] != null) {
+						extraInformation += Messages.getString("HttpSslHandler.32"); //$NON-NLS-1$
+					}
+					if (filenames[2] != null) {
+						extraInformation += Messages.getString("HttpSslHandler.44"); //$NON-NLS-1$
+					}
+					if (filenames[3] != null) {
+						extraInformation += Messages.getString("HttpSslHandler.45"); //$NON-NLS-1$
+					}
+					if (filenames[4] != null) {
+						extraInformation += Messages.getString("HttpSslHandler.46"); //$NON-NLS-1$
 					}
 				} else if (act.equalsIgnoreCase("Disconnect")) {
 					String logon = Logon();

--- a/src/main/java/org/waarp/openr66/protocol/localhandler/ConnectionActions.java
+++ b/src/main/java/org/waarp/openr66/protocol/localhandler/ConnectionActions.java
@@ -262,15 +262,17 @@ public abstract class ConnectionActions {
 		if (localChannelReference == null) {
 			session.newState(ERROR);
 			logger.error(Messages.getString("LocalServerHandler.1")); //$NON-NLS-1$
-			ErrorPacket error = new ErrorPacket("Cannot startup connection",
-					ErrorCode.ConnectionImpossible.getCode(), ErrorPacket.FORWARDCLOSECODE);
-			try {
-				Channels.write(channel, error).await();
-			} catch (InterruptedException e) {
+			if (channel.isConnected()) {
+				ErrorPacket error = new ErrorPacket("Cannot startup connection",
+						ErrorCode.ConnectionImpossible.getCode(), ErrorPacket.FORWARDCLOSECODE);
+				try {
+					Channels.write(channel, error).await();
+				} catch (InterruptedException e) {
+				}
+				// Cannot do writeBack(error, true);
+				session.setStatus(40);
+				ChannelCloseTimer.closeFutureChannel(channel);
 			}
-			// Cannot do writeBack(error, true);
-			session.setStatus(40);
-			ChannelCloseTimer.closeFutureChannel(channel);
 			return;
 		}
 		session.newState(STARTUP);

--- a/src/main/java/org/waarp/openr66/protocol/localhandler/LocalServerHandler.java
+++ b/src/main/java/org/waarp/openr66/protocol/localhandler/LocalServerHandler.java
@@ -76,6 +76,7 @@ import org.waarp.openr66.protocol.localhandler.packet.json.JsonPacket;
 import org.waarp.openr66.protocol.localhandler.packet.json.RequestJsonPacket;
 import org.waarp.openr66.protocol.utils.ChannelCloseTimer;
 import org.waarp.openr66.protocol.utils.ChannelUtils;
+import org.waarp.openr66.protocol.utils.R66ShutdownHook;
 
 /**
  * The local server handler handles real end file operations.
@@ -340,6 +341,7 @@ public class LocalServerHandler extends SimpleChannelHandler {
 			serverHandler.getSession().newState(ERROR);
 			boolean isAnswered = false;
 			if (exception instanceof OpenR66ProtocolShutdownException) {
+				R66ShutdownHook.shutdownWillStart();
 				logger.warn(Messages.getString("LocalServerHandler.0") + //$NON-NLS-1$
 						serverHandler.getSession().getAuth().getUser());
 				if (serverHandler.getLocalChannelReference() != null) {

--- a/src/main/java/org/waarp/openr66/protocol/localhandler/LocalTransaction.java
+++ b/src/main/java/org/waarp/openr66/protocol/localhandler/LocalTransaction.java
@@ -42,6 +42,7 @@ import org.waarp.openr66.context.R66Session;
 import org.waarp.openr66.context.task.exception.OpenR66RunnerErrorException;
 import org.waarp.openr66.database.data.DbTaskRunner;
 import org.waarp.openr66.protocol.configuration.Configuration;
+import org.waarp.openr66.protocol.exception.OpenR66ProtocolNoConnectionException;
 import org.waarp.openr66.protocol.exception.OpenR66ProtocolPacketException;
 import org.waarp.openr66.protocol.exception.OpenR66ProtocolRemoteShutdownException;
 import org.waarp.openr66.protocol.exception.OpenR66ProtocolShutdownException;
@@ -52,6 +53,7 @@ import org.waarp.openr66.protocol.localhandler.packet.ValidPacket;
 import org.waarp.openr66.protocol.networkhandler.NetworkChannelReference;
 import org.waarp.openr66.protocol.networkhandler.packet.NetworkPacket;
 import org.waarp.openr66.protocol.utils.R66Future;
+import org.waarp.openr66.protocol.utils.R66ShutdownHook;
 
 /**
  * This class handles Local Transaction connections
@@ -134,10 +136,11 @@ public class LocalTransaction {
 	 * @return the LocalChannelReference
 	 * @throws OpenR66ProtocolSystemException
 	 * @throws OpenR66ProtocolRemoteShutdownException 
+	 * @throws OpenR66ProtocolNoConnectionException 
 	 */
 	public LocalChannelReference createNewClient(NetworkChannelReference networkChannelReference,
 			Integer remoteId, R66Future futureRequest)
-			throws OpenR66ProtocolSystemException, OpenR66ProtocolRemoteShutdownException {
+			throws OpenR66ProtocolSystemException, OpenR66ProtocolRemoteShutdownException, OpenR66ProtocolNoConnectionException {
 		networkChannelReference.getLock().lock();
 		try {
 			ChannelFuture channelFuture = null;
@@ -145,6 +148,13 @@ public class LocalTransaction {
 					.getClass().getName(), serverChannel.getConfig()
 					.getConnectTimeoutMillis() + " " + serverChannel.isBound());
 			for (int i = 0; i < Configuration.RETRYNB; i++) {
+				if (R66ShutdownHook.isShutdownStarting()) {
+					// Do not try since already locally in shutdown
+					throw new OpenR66ProtocolNoConnectionException(
+							"Cannot connect to local handler: " + socketLocalServerAddress +
+									" " + serverChannel.isBound() + " " + serverChannel +
+									" since the local server is in shutdown.");
+				}
 				channelFuture = clientBootstrap.connect(socketLocalServerAddress);
 				try {
 					channelFuture.await();

--- a/src/main/java/org/waarp/openr66/protocol/localhandler/ServerActions.java
+++ b/src/main/java/org/waarp/openr66/protocol/localhandler/ServerActions.java
@@ -35,6 +35,7 @@ import org.jboss.netty.channel.Channel;
 import org.jboss.netty.channel.Channels;
 import org.waarp.common.command.exception.CommandAbstractException;
 import org.waarp.common.database.DbPreparedStatement;
+import org.waarp.common.database.DbSession;
 import org.waarp.common.database.data.AbstractDbData;
 import org.waarp.common.database.exception.WaarpDatabaseException;
 import org.waarp.common.database.exception.WaarpDatabaseNoConnectionException;
@@ -1431,9 +1432,25 @@ public class ServerActions extends ConnectionActions {
 			Configuration.configuration.r66Mib.notifyWarning(
 					"Export Configuration Order received", session.getAuth().getUser());
 		}
-		String shost = null, srule = null, sbusiness = null, salias = null, sroles = null;
 		String dir = Configuration.configuration.baseDirectory +
 				Configuration.configuration.archivePath;
+		return staticConfigExport(localChannelReference.getDbSession(), dir, bhost, brule, bbusiness, balias, broles);
+	}
+	
+	/**
+	 * Export configuration and return filenames in order
+	 * @param dbSession
+	 * @param dir
+	 * @param bhost
+	 * @param brule
+	 * @param bbusiness
+	 * @param balias
+	 * @param broles
+	 * @return filenames in order
+	 */
+	public static String [] staticConfigExport(DbSession dbSession, String dir, boolean bhost, boolean brule, 
+			boolean bbusiness, boolean balias, boolean broles) {
+		String shost = null, srule = null, sbusiness = null, salias = null, sroles = null;
 		String hostname = Configuration.configuration.HOST_ID;
 		if (bhost) {
 			String filename = dir + File.separator + hostname + "_Authentications.xml";
@@ -1474,7 +1491,7 @@ public class ServerActions extends ConnectionActions {
 		}
 		if (bbusiness || balias || broles) {
 			try {
-				DbHostConfiguration host = new DbHostConfiguration(localChannelReference.getDbSession(), Configuration.configuration.HOST_ID);
+				DbHostConfiguration host = new DbHostConfiguration(dbSession, Configuration.configuration.HOST_ID);
 				if (bbusiness) {
 					sbusiness = host.getBusiness();
 					if (sbusiness != null) {

--- a/src/main/java/org/waarp/openr66/protocol/networkhandler/NetworkChannelReference.java
+++ b/src/main/java/org/waarp/openr66/protocol/networkhandler/NetworkChannelReference.java
@@ -102,16 +102,12 @@ public class NetworkChannelReference {
 
 	public void add(LocalChannelReference localChannel)
 			throws OpenR66ProtocolRemoteShutdownException {
-		lock.lock();
-		try {
-			if (isShuttingDown) {
-				throw new OpenR66ProtocolRemoteShutdownException("Current NetworkChannelReference is closed");
-			}
-			use();
-			localChannelReferences.add(localChannel);
-		} finally {
-			lock.unlock();
+		// lock is of no use since caller is itself in locked situation for the very same lock
+		if (isShuttingDown) {
+			throw new OpenR66ProtocolRemoteShutdownException("Current NetworkChannelReference is closed");
 		}
+		use();
+		localChannelReferences.add(localChannel);
 	}
 	
 	/**
@@ -133,6 +129,11 @@ public class NetworkChannelReference {
 		}
 		return false;
 	}
+	
+	/**
+	 * Remove one LocalChanelReference, closing it if necessary.
+	 * @param localChannel
+	 */
 	public void remove(LocalChannelReference localChannel) {
 		lock.lock();
 		try {

--- a/src/main/java/org/waarp/openr66/protocol/utils/FileUtils.java
+++ b/src/main/java/org/waarp/openr66/protocol/utils/FileUtils.java
@@ -343,11 +343,13 @@ public class FileUtils {
 				} else {
 					filename = filename.substring("file:".length());
 				}
-				try {
-					filename = URLDecoder.decode(filename, WaarpStringUtils.UTF8.name());
-				} catch (UnsupportedEncodingException e) {
-					logger.warn("Filename convertion to UTF8 cannot be read: " +
-							filename);
+				if (filename.contains("%")) {
+					try {
+						filename = URLDecoder.decode(filename, WaarpStringUtils.UTF8.name());
+					} catch (UnsupportedEncodingException e) {
+						logger.warn("Filename convertion to UTF8 cannot be read: " +
+								filename);
+					}
 				}
 			}
 			logger.debug("File becomes: "+filename);
@@ -370,13 +372,15 @@ public class FileUtils {
 					// no test on file since it does not really exist
 					logger.debug("File is in through mode: {}", file);
 				} else if (!file.canRead()) {
+					logger.debug("File {} cannot be read, so try external from "+filename, file);
 					// file is not under normal base directory, so is external
 					// File should already exist but cannot use special code ('*?')
-					file = new R66File(session, session.getDir(), filename);
-					if (!file.canRead()) {
+					R66File file2 = new R66File(session, session.getDir(), filename);
+					if (!file2.canRead()) {
 						throw new OpenR66RunnerErrorException("File cannot be read: " +
 								file.getTrueFile().getAbsolutePath());
 					}
+					file = file2;
 				}
 			} catch (CommandAbstractException e) {
 				throw new OpenR66RunnerErrorException(e);

--- a/src/main/java/org/waarp/openr66/protocol/utils/Version.java
+++ b/src/main/java/org/waarp/openr66/protocol/utils/Version.java
@@ -3,7 +3,7 @@ package org.waarp.openr66.protocol.utils;
 /** Provides the version information of Waarp OpenR66. */
 public final class Version {
  /** The version identifier. */
- public static final String ID = "2.4.25";
+ public static final String ID = "2.4.26";
  /** Prints out the version identifier to stdout. */
  public static void main(String[] args) { System.out.println(ID); }
  private Version() { super(); }


### PR DESCRIPTION
Fix DbTaskRunner LRU cache
Add option -Dopenr66.cache.limit and -Dopenr66.cache.timelimit
Improve Log in SpooledDirectory
Improve Directory and File implementation
Improve Shutdown for SpooledDirectory
Add programmatic support of equivalent of -Dfile.encoding=UTF-8
Use LongUuid support for SpecialId when no database is used
Improve LRU cache usage, lock and preventing deadlock in NetworkTransaction
