### PR TITLE
Allow clients to fetch files from subdirectories of remote servers with MultipleDirectTransfer and MultipleSubmitTransfer

### DIFF
--- a/src/main/java/messages.properties
+++ b/src/main/java/messages.properties
@@ -590,6 +590,7 @@ Transfer.14         = Issue with file:
 Transfer.18         = Rule error: 
 Transfer.3          = Ask for 
 Transfer.6          = Error Asking for 
+Transfer.7          = Filename does not match the user pattern
 Transfer.FailedNoId = Transfer in status: FAILED with no Transfer Id
 Transfer.Status     = Transfer in status:      
 

--- a/src/main/java/messages_en.properties
+++ b/src/main/java/messages_en.properties
@@ -590,6 +590,7 @@ Transfer.14         = Issue with file:
 Transfer.18         = Rule error: 
 Transfer.3          = Ask for 
 Transfer.6          = Error Asking for 
+Transfer.7          = Filename does not match the user pattern :
 Transfer.FailedNoId = Transfer in status: FAILED with no Transfer Id
 Transfer.Status     = Transfer in status:      
 

--- a/src/main/java/messages_fr.properties
+++ b/src/main/java/messages_fr.properties
@@ -644,6 +644,7 @@ Transfer.14         = Probleme avec le fichier:
 Transfer.18         = Erreur sur la Regle: 
 Transfer.3          = Demande de 
 Transfer.6          = Erreur en demandant 
+Transfer.7          = Le nom du fichier ne correspond pas au motif fourni par l'iutilisateur :
 Transfer.FailedNoId = Transfert avec un statut: ECHEC sans Id de Transfert
 Transfer.Status     = Transfert avec un statut:      
 

--- a/src/main/java/org/waarp/openr66/client/MultipleDirectTransfer.java
+++ b/src/main/java/org/waarp/openr66/client/MultipleDirectTransfer.java
@@ -20,6 +20,8 @@ package org.waarp.openr66.client;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
 
 import org.jboss.netty.logging.InternalLoggerFactory;
 import org.waarp.common.command.exception.CommandAbstractException;
@@ -90,9 +92,18 @@ public class MultipleDirectTransfer extends DirectTransfer {
 					if (valid != null) {
 						String line = valid.getSheader();
 						String []lines = line.split("\n");
+
+						String patternStr = filename.replace(".", "\\.").replace("?", ".").replace("*", ".*?");
+						Pattern pattern = Pattern.compile(patternStr);
+
 						for (String string : lines) {
-							File tmpFile = new File(string);
-							files.add(tmpFile.getName());
+							Matcher matcher = pattern.matcher(string);
+							if (matcher.find()) {
+								files.add(matcher.group(0));
+							} else {
+								logger.warning(Messages.getString("Transfer.7") + filename);
+							}
+
 						}
 					}
 				} else {


### PR DESCRIPTION
While R66 clients can list files in subdirectories of the out folder of a R66 server MultipleDirectTransfer and MultipleSubmitTransfer, they cannot fetch them (with a pull rule) because of the use of tmpFile.getName().

For example (data/out being the "out" dir of the server) :

```
# on the server :
server $ ls data/out/**/*
client/test2.dat

# on the client
server $ java [...] MultipleDirectTransfer -file client/test?.dat -rule multidest -to server -client
[Unique MultipleDirectTransfer] Transfer in status: FAILED with no Transfer Id
{"command":"Unique MultipleDirectTransfer","status":2,"statusTxt":"Transfer in status: FAILED with no Transfer Id","remote":"server","error":"ErrorPacket:(3:f) PreTask in error: File cannot be read: /path/to/data/out/test2.dat"}
```

I don't know if using regex was the best solution, but it works well like that
