### PR TITLE
Fixes null pointer errors on Configuration.configuration.r66Mib

### DIFF
--- a/src/main/java/org/waarp/openr66/protocol/networkhandler/NetworkServerHandler.java
+++ b/src/main/java/org/waarp/openr66/protocol/networkhandler/NetworkServerHandler.java
@@ -142,8 +142,10 @@ public class NetworkServerHandler extends IdleStateAwareChannelHandler {
 		if (NetworkTransaction.isBlacklisted(netChannel)) {
 			logger.warn("Connection refused since Partner is BlackListed from "+remoteAddress.toString());
 			isBlackListed = true;
-			Configuration.configuration.r66Mib.notifyError(
-					"Black Listed connection temptative", "During connection");
+			if (Configuration.configuration.r66Mib != null) {
+				Configuration.configuration.r66Mib.notifyError(
+						"Black Listed connection temptative", "During connection");
+			}
 			// close immediately the connection
 			WaarpSslUtility.closingSslChannel(netChannel);
 			return;

--- a/src/main/java/org/waarp/openr66/protocol/networkhandler/ssl/NetworkSslServerHandler.java
+++ b/src/main/java/org/waarp/openr66/protocol/networkhandler/ssl/NetworkSslServerHandler.java
@@ -108,8 +108,10 @@ public class NetworkSslServerHandler extends NetworkServerHandler {
 		if (NetworkTransaction.isBlacklisted(networkChannel)) {
 			logger.warn("Connection refused since Partner is in BlackListed from "+networkChannel.getRemoteAddress().toString());
 			isBlackListed = true;
-			Configuration.configuration.r66Mib.notifyError(
-					"Black Listed connection temptative", "During Handshake");
+			if (Configuration.configuration.r66Mib != null) {
+				Configuration.configuration.r66Mib.notifyError(
+						"Black Listed connection temptative", "During Handshake");
+			}
 			// close immediately the connection
 			WaarpSslUtility.closingSslChannel(networkChannel);
 			return;
@@ -128,8 +130,10 @@ public class NetworkSslServerHandler extends NetworkServerHandler {
 				// Get the SslHandler and begin handshake ASAP.
 				// Get notified when SSL handshake is done.
 				if (! WaarpSslUtility.runHandshake(ctx.getChannel())) {
-					Configuration.configuration.r66Mib.notifyError(
-							"SSL Connection Error", "During Handshake");
+					if (Configuration.configuration.r66Mib != null) {
+						Configuration.configuration.r66Mib.notifyError(
+								"SSL Connection Error", "During Handshake");
+					}
 				}
 			}
 			logger.debug("Ssl done for channel");


### PR DESCRIPTION
In these 3 cases, there are no checks that Configuration.configuration.r66Mib is not null
