### PR TITLE
Make FileUtils.copy() handle empty files

### DIFF
--- a/src/main/java/org/waarp/openr66/protocol/utils/FileUtils.java
+++ b/src/main/java/org/waarp/openr66/protocol/utils/FileUtils.java
@@ -88,7 +88,7 @@ public class FileUtils {
                 throw new OpenR66ProtocolSystemException(
                         "Cannot write destination file");
             }
-            if (write(fileChannelIn, fileChannelOut) > 0) {
+            if (write(fileChannelIn, fileChannelOut) > -1) {
                 if (move) {
                     // do not test the delete
                     from.delete();


### PR DESCRIPTION
It allows the transfer of empty files whithout the need of the UNZEROED task