### PR TITLE
Forces the destination path of a copy task to end with a slash

### DIFF
--- a/src/main/java/org/waarp/openr66/context/task/CopyTask.java
+++ b/src/main/java/org/waarp/openr66/context/task/CopyTask.java
@@ -58,7 +58,8 @@ public class CopyTask extends AbstractTask {
         logger.info("Copy with " + argRule + ":" + argTransfer + " and {}",
                 session);
         File from = session.getFile().getTrueFile();
-        File to = new File(argRule.replace('\\', '/') + session.getFile().getBasename());
+        String directory = argRule.replace('\\', '/');
+        File to = new File(directory, session.getFile().getBasename());
         try {
             FileUtils.copy(from, to, false, false);
         } catch (OpenR66ProtocolSystemException e1) {


### PR DESCRIPTION
If not, if transfer is, for example "/home/tmp", the COPY task is actually a COPYRENAME one with the path `/home/tmp#TRUEFILENAME#`