### PR TITLE
W netty41

### DIFF
--- a/src/main/httpadmin/admin-bootstrap/CancelRestart.html
+++ b/src/main/httpadmin/admin-bootstrap/CancelRestart.html
@@ -93,7 +93,7 @@ var prepareTable = function() {
 					  { data: "UPDATEDINFO", title :i18n.t("menu2.entete9"), render: renderGeneric, createdCell: createdCellInfoColor},
 					  { data: "RANK", title :i18n.t("menu2.entete10"), render: function(data, type, row, meta) {
 						  var gsize = row.ORIGINALSIZE;
-						  if (gsize > 0) {var percent = ~~(data*row.BLOCKSZ/gsize*100);
+						  if (gsize > 0) {var percent = ~~(data*row.BLOCKSZ/gsize*100); if (percent > 100) percent = 100;
 							return blockString1+data+blockString2+percent+blockString3;} else {return data;}
 					  }},
 					  { data: "BLOCKSZ", title :i18n.t("menu2.entete22")},

--- a/src/main/httpadmin/admin-bootstrap/Listing.html
+++ b/src/main/httpadmin/admin-bootstrap/Listing.html
@@ -79,7 +79,7 @@ var prepareTable = function() {
 					  { data: "UPDATEDINFO", title :i18n.t("menu2.entete9"), render: renderGeneric, createdCell: createdCellInfoColor},
 					  { data: "RANK", title :i18n.t("menu2.entete10"), render: function(data, type, row, meta) {
 						  var gsize = row.ORIGINALSIZE;
-						  if (gsize > 0) {var percent = ~~(data*row.BLOCKSZ/gsize*100);
+						  if (gsize > 0) {var percent = ~~(data*row.BLOCKSZ/gsize*100);  if (percent > 100) percent = 100;
 							return blockString1+data+blockString2+percent+blockString3;} else {return data;}
 					  }},
 					  { data: "BLOCKSZ", title :i18n.t("menu2.entete22")},

--- a/src/main/httpadmin/i18n/System.html
+++ b/src/main/httpadmin/i18n/System.html
@@ -138,7 +138,7 @@ a img {
 							The value (in Byte per second) specifies the limit of write bandwidth (out) globally (cumulative). 0 means no limit. Must be greater than 1KBs.
 							</p></div><br/>
 						    <label data-i18n="menu5.filtre21">Delay for traffic shaping (ms):</label>
-						    <input type="text" name="DTRA" size="20" value="XXXXDELAYTRAFFICXXX">
+						    <input type="text" name="DTRA" size="20" value="XXXXDELATRAFFICXXX">
 						    <img id="dthelp" alt="help for Delay for traffic shaping field"  class="help" width="16" height="16" src="img/help_small.gif" />
 							<div id="containerdthelp"><p data-i18n="menu5.filtre22" class="cshelp">
 							Delay for Traffic Shaping between two checks in ms. Must be greater than 100ms.

--- a/src/main/java/org/waarp/gateway/kernel/exec/AbstractExecutor.java
+++ b/src/main/java/org/waarp/gateway/kernel/exec/AbstractExecutor.java
@@ -20,6 +20,7 @@ import org.waarp.common.command.exception.CommandAbstractException;
 import org.waarp.common.future.WaarpFuture;
 import org.waarp.common.logging.WaarpLogger;
 import org.waarp.common.logging.WaarpLoggerFactory;
+import org.waarp.common.utility.UUID;
 import org.waarp.gateway.kernel.session.CommandExecutorInterface;
 import org.waarp.gateway.kernel.session.HttpAuthInterface;
 
@@ -42,6 +43,7 @@ import org.waarp.gateway.kernel.session.HttpAuthInterface;
  * - #ACCOUNT# is replaced by the account<br>
  * - #COMMAND# is replaced by the command issued for the file<br>
  * - #SPECIALID# is replaced by the FTP id of the transfer (whatever in or out)<br>
+ * - #UUID# is replaced by a special UUID globally unique for the transfer, in general to be placed in -info part (for instance ##UUID## giving #uuid#)<br>
  * 
  * @author Frederic Bregier
  * 
@@ -58,6 +60,7 @@ public abstract class AbstractExecutor {
     protected static final String FILE = "#FILE#";
     protected static final String COMMAND = "#COMMAND#";
     protected static final String SPECIALID = "#SPECIALID#";
+    protected static final String sUUID = "#sUUID#";
 
     protected static final String REFUSED = "REFUSED";
     protected static final String NONE = "NONE";
@@ -377,6 +380,9 @@ public abstract class AbstractExecutor {
         replaceAll(builder, FILE, args[3]);
         replaceAll(builder, COMMAND, args[4]);
         replaceAll(builder, SPECIALID, args[5]);
+        if (builder.indexOf(sUUID) > 0) {
+            replaceAll(builder, sUUID, new UUID().toString());
+        }
         logger.debug("Result: {}", builder);
         return builder.toString();
     }

--- a/src/main/java/org/waarp/gateway/kernel/exec/ExecuteExecutor.java
+++ b/src/main/java/org/waarp/gateway/kernel/exec/ExecuteExecutor.java
@@ -41,6 +41,8 @@ import org.waarp.common.logging.WaarpLoggerFactory;
  * - #USER# is replaced by the username<br>
  * - #ACCOUNT# is replaced by the account<br>
  * - #COMMAND# is replaced by the command issued for the file<br>
+ * - #SPECIALID# is replaced by the FTP id of the transfer (whatever in or out)<br>
+ * - #UUID# is replaced by a special UUID globally unique for the transfer, in general to be placed in -info part (for instance ##UUID## giving #uuid#)<br>
  * 
  * @author Frederic Bregier
  * 

--- a/src/main/java/org/waarp/gateway/kernel/exec/R66PreparedTransferExecutor.java
+++ b/src/main/java/org/waarp/gateway/kernel/exec/R66PreparedTransferExecutor.java
@@ -57,9 +57,10 @@ import org.waarp.openr66.protocol.localhandler.packet.RequestPacket;
  * - #ACCOUNT# is replaced by the account<br>
  * - #COMMAND# is replaced by the command issued for the file<br>
  * - #SPECIALID# is replaced by the FTP id of the transfer (whatever in or out)<br>
+ * - #UUID# is replaced by a special UUID globally unique for the transfer, in general to be placed in -info part (for instance ##UUID## giving #uuid#)<br>
  * <br>
  * So for instance
- * "-to Host -file #BASEPATH##FILE# -rule RULE [-md5] [-nolog] [-delay +delay]  [-info #USER# #ACCOUNT# #COMMAND# INFO]" <br>
+ * "-to Host -file #BASEPATH##FILE# -rule RULE [-md5] [-nolog] [-delay +delay]  [-info ##UUID## #USER# #ACCOUNT# #COMMAND# INFO]" <br>
  * will be a standard use of this function.
  * 
  * @author Frederic Bregier

--- a/src/main/java/org/waarp/openr66/context/R66Session.java
+++ b/src/main/java/org/waarp/openr66/context/R66Session.java
@@ -701,6 +701,7 @@ public class R66Session implements SessionInterface {
             // generated due to a possible wildcard not ready
             file = null;
         }
+        logger.debug("GlobalLastStep: " + runner.getGloballaststep());
         if (runner.getGloballaststep() == TASKSTEP.TRANSFERTASK.ordinal()) {
             if (this.businessObject != null) {
                 this.businessObject.checkAfterPreCommand(this);

--- a/src/main/java/org/waarp/openr66/context/task/AbstractTask.java
+++ b/src/main/java/org/waarp/openr66/context/task/AbstractTask.java
@@ -23,6 +23,8 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 
 import org.waarp.common.command.exception.CommandAbstractException;
+import org.waarp.common.logging.WaarpLogger;
+import org.waarp.common.logging.WaarpLoggerFactory;
 import org.waarp.common.utility.WaarpStringUtils;
 import org.waarp.openr66.context.ErrorCode;
 import org.waarp.openr66.context.R66Session;
@@ -40,6 +42,12 @@ import org.waarp.openr66.protocol.utils.R66Future;
  * 
  */
 public abstract class AbstractTask implements Runnable {
+    /**
+     * Internal Logger
+     */
+    private static final WaarpLogger logger = WaarpLoggerFactory
+            .getLogger(AbstractTask.class);
+
     /**
      * Current full path of current FILENAME
      */
@@ -446,7 +454,12 @@ public abstract class AbstractTask implements Runnable {
         }
         // finalname
         if (argFormat != null && argFormat.length > 0)
-            return String.format(builder.toString(), argFormat);
+            try {
+                return String.format(builder.toString(), argFormat);
+            } catch (Exception e) {
+                // ignored error since bad argument in static rule info
+                logger.error("Bad format in Rule: {"+builder.toString()+"} " + e.getMessage());
+            }
         return builder.toString();
     }
 }

--- a/src/main/java/org/waarp/openr66/context/task/AddUuidJavaTask.java
+++ b/src/main/java/org/waarp/openr66/context/task/AddUuidJavaTask.java
@@ -1,0 +1,66 @@
+/**
+   This file is part of Waarp Project.
+
+   Copyright 2009, Frederic Bregier, and individual contributors by the @author
+   tags. See the COPYRIGHT.txt in the distribution for a full listing of
+   individual contributors.
+
+   All Waarp Project is free software: you can redistribute it and/or 
+   modify it under the terms of the GNU General Public License as published 
+   by the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   Waarp is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with Waarp .  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.waarp.openr66.context.task;
+
+import org.waarp.common.database.exception.WaarpDatabaseException;
+import org.waarp.common.logging.WaarpLogger;
+import org.waarp.common.logging.WaarpLoggerFactory;
+import org.waarp.common.utility.UUID;
+
+/**
+ * Add an UUID in the TransferInformation to the current Task.</br>
+ * This should be called on caller side in pre-task since the transfer information will be transfered just after.</br>
+ * The last argument is -1 = added in front, +1 = added at last (mandatory).</br>
+ * </br>
+ * To be called as: <task><type>EXECJAVA</type><path>org.waarp.openr66.context.task.AddUuidJavaTask (-1/+1)</path></task> 
+ * 
+ * @author "Frederic Bregier"
+ *
+ */
+public class AddUuidJavaTask extends AbstractExecJavaTask {
+    /**
+     * Internal Logger
+     */
+    private static final WaarpLogger logger = WaarpLoggerFactory
+            .getLogger(AddUuidJavaTask.class);
+
+    @Override
+    public void run() {
+        UUID uuid = new UUID();
+        String way = fullarg.split(" ")[0];
+        String fileInfo = null;
+        if (way.charAt(0) == '-') {
+            fileInfo = "#" + uuid.toString() + "# " + this.session.getRunner().getFileInformation();
+        } else {
+            fileInfo = this.session.getRunner().getFileInformation() + " #" + uuid.toString() + "#";
+        }
+        this.session.getRunner().setFileInformation(fileInfo);
+        try {
+            this.session.getRunner().update();
+        } catch (WaarpDatabaseException e) {
+            logger.error("UUID cannot be saved to fileInformation:" + fileInfo);
+            this.status = 2;
+            return;
+        }
+        logger.debug("UUID saved to fileInformation:" + fileInfo);
+        this.status = 0;
+    }
+}

--- a/src/main/java/org/waarp/openr66/context/task/TransferTask.java
+++ b/src/main/java/org/waarp/openr66/context/task/TransferTask.java
@@ -36,8 +36,9 @@ import org.waarp.openr66.protocol.utils.R66Future;
  * Transfer task:<br>
  * 
  * Result of arguments will be as r66send command.<br>
- * Format is like r66send command in any order except "-info" which should be the last item:<br>
- * "-file filepath -to requestedHost -rule rule [-md5] [-start yyyyMMddHHmmss or -delay (delay or +delay)] [-info information]" <br>
+ * Format is like r66send command in any order except "-info" which should be the last item, and "-copyinfo"
+ * will copy at first place the original transfer information as the new one, while still having the possibility to add new informations through "-info":<br>
+ * "-file filepath -to requestedHost -rule rule [-md5] [-start yyyyMMddHHmmss or -delay (delay or +delay)] [-copyinfo] [-info information]" <br>
  * <br>
  * INFO is the only one field that can contains blank character.<br>
  * 
@@ -82,6 +83,7 @@ public class TransferTask extends AbstractTask {
         String requested = null;
         String rule = null;
         String information = null;
+        String finalInformation = null;
         boolean isMD5 = false;
         int blocksize = Configuration.configuration.BLOCKSIZE;
         Timestamp timestart = null;
@@ -95,6 +97,8 @@ public class TransferTask extends AbstractTask {
             } else if (args[i].equalsIgnoreCase("-rule")) {
                 i++;
                 rule = args[i];
+            } else if (args[i].equalsIgnoreCase("-copyinfo")) {
+                finalInformation = argTransfer;
             } else if (args[i].equalsIgnoreCase("-info")) {
                 i++;
                 information = args[i];
@@ -134,12 +138,18 @@ public class TransferTask extends AbstractTask {
                 }
             }
         }
-        if (information == null) {
-            information = "noinfo";
+        if (information != null) {
+            if (finalInformation == null) {
+                finalInformation = information;
+            } else {
+                finalInformation += " " + information;
+            }
+        } else if (finalInformation == null) {
+            finalInformation = "noinfo";
         }
         R66Future future = new R66Future(true);
         SubmitTransfer transaction = new SubmitTransfer(future,
-                requested, filepath, rule, information, isMD5, blocksize, DbConstant.ILLEGALVALUE,
+                requested, filepath, rule, finalInformation, isMD5, blocksize, DbConstant.ILLEGALVALUE,
                 timestart);
         transaction.run();
         future.awaitUninterruptibly();

--- a/src/main/java/org/waarp/openr66/context/task/javatask/AddDigestJavaTask.java
+++ b/src/main/java/org/waarp/openr66/context/task/javatask/AddDigestJavaTask.java
@@ -1,0 +1,109 @@
+/**
+   This file is part of Waarp Project.
+
+   Copyright 2009, Frederic Bregier, and individual contributors by the @author
+   tags. See the COPYRIGHT.txt in the distribution for a full listing of
+   individual contributors.
+
+   All Waarp Project is free software: you can redistribute it and/or 
+   modify it under the terms of the GNU General Public License as published 
+   by the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   Waarp is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with Waarp .  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.waarp.openr66.context.task.javatask;
+
+import java.io.IOException;
+
+import org.waarp.common.database.exception.WaarpDatabaseException;
+import org.waarp.common.digest.FilesystemBasedDigest;
+import org.waarp.common.digest.FilesystemBasedDigest.DigestAlgo;
+import org.waarp.common.logging.WaarpLogger;
+import org.waarp.common.logging.WaarpLoggerFactory;
+import org.waarp.openr66.context.task.AbstractExecJavaTask;
+
+/**
+ * Add a digest in the TransferInformation to the current Task.</br>
+ * This should be called on caller side in pre-task since the transfer information will be transfered just after.</br>
+ * The second argument is -digest followed by one of ADLER32 CRC32 MD2 MD5 SHA1 SHA256 SHA384 SHA512, default being MD5.</br>
+ * The third argument, optional, is "-format" followed by a string containing "#DIGEST#" to be replaced by the digest 
+ * and starting with - or +, meaning this will be added at the beginning or the end of the generated new string. Default is equivalent to "-format -##DIGEST##".</br>
+ * </br>
+ * To be called as: <task><type>EXECJAVA</type><path>org.waarp.openr66.context.task.javatask.AddDigestJavaTask -digest ADLER32|CRC32|MD2|MD5|SHA1|SHA256|SHA384|SHA512 [-format (-/+)##DIGEST##]</path></task> 
+ * 
+ * @author "Frederic Bregier"
+ *
+ */
+public class AddDigestJavaTask extends AbstractExecJavaTask {
+    /**
+     * Internal Logger
+     */
+    private static final WaarpLogger logger = WaarpLoggerFactory
+            .getLogger(AddDigestJavaTask.class);
+
+    private static final String sDIGEST = "#DIGEST#";
+    @Override
+    public void run() {
+        logger.debug(this.toString());
+        String []args = fullarg.split(" ");
+        String fileInfo = null;
+        String format = "-##DIGEST##";
+        String algo = "MD5";
+        int way = -1;
+        for (int i = 0; i < args.length; i++) {
+            if (args[i].equalsIgnoreCase("-format")) {
+                format = args[i+1];
+                if (format.charAt(0) == '-') {
+                    way = -1;
+                    format = format.substring(1);
+                } else if (format.charAt(0) == '+') {
+                    way = 1;
+                    format = format.substring(1);
+                }
+                i++;
+            } else if (args[i].equals("-digest")) {
+                algo = args[i+1].toUpperCase();
+                i++;
+            }
+        }
+        DigestAlgo digest = null;
+        try {
+            digest = DigestAlgo.valueOf(algo);
+        } catch (Exception e) {
+            logger.error("Bad algorithm format: " + algo);
+            this.status = 3;
+            return;
+        }
+        String key;
+        try {
+            key = FilesystemBasedDigest.getHex(FilesystemBasedDigest.getHash(this.session.getFile().getTrueFile(), true, digest));
+        } catch (IOException e1) {
+            logger.error("Digest not correctly computed: " + algo, e1);
+            this.status = 4;
+            return;
+        }
+        logger.debug("Replace Digest in {} way: {} digest: {} key: {}", format, way, algo, key);
+        if (way < 0) {
+            fileInfo = format.replace(sDIGEST, key) + " " + this.session.getRunner().getFileInformation();
+        } else {
+            fileInfo = this.session.getRunner().getFileInformation() + " " + format.replace(sDIGEST, key);
+        }
+        this.session.getRunner().setFileInformation(fileInfo);
+        try {
+            this.session.getRunner().update();
+        } catch (WaarpDatabaseException e) {
+            logger.error("Digest cannot be saved to fileInformation:" + fileInfo);
+            this.status = 2;
+            return;
+        }
+        logger.debug("Digest saved to fileInformation:" + fileInfo);
+        this.status = 0;
+    }
+}

--- a/src/main/java/org/waarp/openr66/context/task/javatask/AddUuidJavaTask.java
+++ b/src/main/java/org/waarp/openr66/context/task/javatask/AddUuidJavaTask.java
@@ -18,19 +18,22 @@
    You should have received a copy of the GNU General Public License
    along with Waarp .  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.waarp.openr66.context.task;
+package org.waarp.openr66.context.task.javatask;
 
 import org.waarp.common.database.exception.WaarpDatabaseException;
 import org.waarp.common.logging.WaarpLogger;
 import org.waarp.common.logging.WaarpLoggerFactory;
 import org.waarp.common.utility.UUID;
+import org.waarp.openr66.context.task.AbstractExecJavaTask;
 
 /**
  * Add an UUID in the TransferInformation to the current Task.</br>
  * This should be called on caller side in pre-task since the transfer information will be transfered just after.</br>
- * The last argument is -1 = added in front, +1 = added at last (mandatory).</br>
+ * The second argument is -1 = added in front, +1 = added at last, default being -1.</br>
+ * The third argument, optional, is "-format" followed by a string containing "#UUID#" to be replaced by the uuid
+ * and starting with - or +, meaning this will be added at the beginning or the end of the generated new string. Default is equivalent to "-format -##UUID##".
  * </br>
- * To be called as: <task><type>EXECJAVA</type><path>org.waarp.openr66.context.task.AddUuidJavaTask (-1/+1)</path></task> 
+ * To be called as: <task><type>EXECJAVA</type><path>org.waarp.openr66.context.task.javatask.AddUuidJavaTask [-format (-/+)##UUID##]</path></task> 
  * 
  * @author "Frederic Bregier"
  *
@@ -41,16 +44,33 @@ public class AddUuidJavaTask extends AbstractExecJavaTask {
      */
     private static final WaarpLogger logger = WaarpLoggerFactory
             .getLogger(AddUuidJavaTask.class);
-
+    private static final String sUUID = "#UUID#";
     @Override
     public void run() {
+        logger.debug(this.toString());
         UUID uuid = new UUID();
-        String way = fullarg.split(" ")[0];
+        String []args = fullarg.split(" ");
         String fileInfo = null;
-        if (way.charAt(0) == '-') {
-            fileInfo = "#" + uuid.toString() + "# " + this.session.getRunner().getFileInformation();
+        String format = "-##UUID##";
+        int way = -1;
+        for (int i = 0; i < args.length; i++) {
+            if (args[i].equalsIgnoreCase("-format")) {
+                format = args[i+1];
+                if (format.charAt(0) == '-') {
+                    way = -1;
+                    format = format.substring(1);
+                } else if (format.charAt(0) == '+') {
+                    way = 1;
+                    format = format.substring(1);
+                }
+                i++;
+            }
+        }
+        logger.debug("Replace UUID in {} way: {}", format, way);
+        if (way < 0) {
+            fileInfo = format.replace(sUUID, uuid.toString()) + " " + this.session.getRunner().getFileInformation();
         } else {
-            fileInfo = this.session.getRunner().getFileInformation() + " #" + uuid.toString() + "#";
+            fileInfo = this.session.getRunner().getFileInformation() + " " + format.replace(sUUID, uuid.toString());
         }
         this.session.getRunner().setFileInformation(fileInfo);
         try {

--- a/src/main/java/org/waarp/openr66/database/data/DbTaskRunner.java
+++ b/src/main/java/org/waarp/openr66/database/data/DbTaskRunner.java
@@ -3281,6 +3281,9 @@ public class DbTaskRunner extends AbstractDbData {
             if (this.isSender()) {
                 // Nothing to do since it is the original file
                 this.setPostTask();
+                if (!shallIgnoreSave()) {
+                    this.saveStatus();
+                }
             } else {
                 int poststep = this.step;
                 this.setPostTask();

--- a/src/main/java/org/waarp/openr66/database/data/DbTaskRunner.java
+++ b/src/main/java/org/waarp/openr66/database/data/DbTaskRunner.java
@@ -3274,6 +3274,9 @@ public class DbTaskRunner extends AbstractDbData {
         logger.debug("status: " + status + ":" + finalValue);
 
         if (session == null) {
+            if (localChannelReference == null) {
+                return;
+            }
             this.session = localChannelReference.getSession();
         }
         if (status) {

--- a/src/main/java/org/waarp/openr66/protocol/configuration/PartnerConfiguration.java
+++ b/src/main/java/org/waarp/openr66/protocol/configuration/PartnerConfiguration.java
@@ -80,7 +80,7 @@ public class PartnerConfiguration {
     private String id;
     private ObjectNode root = JsonHandler.createObjectNode();
     private boolean useJson = false;
-
+    private boolean changeFileInfoEnabled = false;
     /**
      * Constructor for an external HostId
      * 
@@ -118,6 +118,9 @@ public class PartnerConfiguration {
         } else {
             logger.debug("NOT UseJson for " + id + ":" + json);
             useJson = false;
+        }
+        if (isVersion2GEQVersion1(R66Versions.V3_0_4.getVersion(), version)) {
+            changeFileInfoEnabled = true;
         }
         JsonHandler.setValue(root, FIELDS.SEPARATOR, sep);
 
@@ -214,6 +217,13 @@ public class PartnerConfiguration {
      */
     public boolean useJson() {
         return useJson;
+    }
+
+    /**
+     * @return the changeFileInfoEnabled
+     */
+    public boolean changeFileInfoEnabled() {
+        return changeFileInfoEnabled;
     }
 
     /**

--- a/src/main/java/org/waarp/openr66/protocol/localhandler/LocalServerHandler.java
+++ b/src/main/java/org/waarp/openr66/protocol/localhandler/LocalServerHandler.java
@@ -160,13 +160,21 @@ public class LocalServerHandler extends SimpleChannelInboundHandler<AbstractLoca
                         String newfilename = fields[0];
                         // potential file size changed
                         long newSize = -1;
+                        String newFileInfo = null;
                         if (fields.length > 1) {
                             try {
-                                newSize = Long.parseLong(fields[fields.length - 1]);
+                                newSize = Long.parseLong(fields[1]);
+                                // potential fileInfo changed
+                                if (fields.length > 2) {
+                                    newFileInfo = fields[2];
+                                }
                             } catch (NumberFormatException e2) {
-                                newfilename += PartnerConfiguration.BAR_SEPARATOR_FIELD + fields[fields.length - 1];
+                                newfilename += PartnerConfiguration.BAR_SEPARATOR_FIELD + fields[1];
                                 newSize = -1;
                             }
+                        }
+                        if (newFileInfo != null && ! newFileInfo.equals(serverHandler.session.getRunner().getFileInformation())) {
+                            serverHandler.requestChangeFileInfo(ctx.channel(), newFileInfo);
                         }
                         serverHandler.requestChangeNameSize(ctx.channel(), newfilename, newSize);
                         packet.clear();
@@ -285,7 +293,13 @@ public class LocalServerHandler extends SimpleChannelInboundHandler<AbstractLoca
                             return;
                         }
                         long newSize = node.getFilesize();
+                        String newFileInfo = node.getFileInfo();
                         logger.debug("NewSize " + newSize + " NewName " + newfilename);
+                        // potential fileInfo changed
+                        if (newFileInfo != null && ! newFileInfo.equals(serverHandler.session.getRunner().getFileInformation())) {
+                            logger.debug("NewSize " + newSize + " NewName " + newfilename + " newFileInfo: " + newFileInfo);
+                            serverHandler.requestChangeFileInfo(ctx.channel(), newFileInfo);
+                        }
                         // potential file size changed
                         serverHandler.requestChangeNameSize(ctx.channel(), newfilename, newSize);
                     } else {

--- a/src/main/java/org/waarp/openr66/protocol/localhandler/TransferActions.java
+++ b/src/main/java/org/waarp/openr66/protocol/localhandler/TransferActions.java
@@ -540,16 +540,28 @@ public class TransferActions extends ServerActions {
             request.setComment(info);
             request.setFilename(runner.getFilename());
             request.setFilesize(packet.getOriginalSize());
-            request.setFileInfo(runner.getFileInformation());
+            String infoTransfer = runner.getFileInformation();
+            if (infoTransfer != null && ! infoTransfer.equals(packet.getFileInformation())) {
+                request.setFileInfo(runner.getFileInformation());
+            }
             JsonCommandPacket validPacket = new JsonCommandPacket(request,
                     LocalPacketFactory.REQUESTPACKET);
             ChannelUtils.writeAbstractLocalPacket(localChannelReference,
                     validPacket, true);
         } else {
-            ValidPacket validPacket = new ValidPacket(info,
+            String infoTransfer = runner.getFileInformation();
+            ValidPacket validPacket;
+            if (infoTransfer != null && ! infoTransfer.equals(packet.getFileInformation())
+                    && localChannelReference.getPartner().changeFileInfoEnabled()) {
+                validPacket = new ValidPacket(info,
                     runner.getFilename() + PartnerConfiguration.BAR_SEPARATOR_FIELD + packet.getOriginalSize()
                     + PartnerConfiguration.BAR_SEPARATOR_FIELD + packet.getFileInformation(),
                     LocalPacketFactory.REQUESTPACKET);
+            } else {
+                validPacket = new ValidPacket(info,
+                        runner.getFilename() + PartnerConfiguration.BAR_SEPARATOR_FIELD + packet.getOriginalSize(),
+                        LocalPacketFactory.REQUESTPACKET);
+            }
             ChannelUtils.writeAbstractLocalPacket(localChannelReference,
                     validPacket, true);
         }

--- a/src/main/java/org/waarp/openr66/protocol/localhandler/TransferActions.java
+++ b/src/main/java/org/waarp/openr66/protocol/localhandler/TransferActions.java
@@ -389,6 +389,9 @@ public class TransferActions extends ServerActions {
             // not valid so create an error from there
             ErrorCode code = ErrorCode.getFromCode("" + packet.getCode());
             session.setBadRunner(runner, code);
+            if (!runner.shallIgnoreSave()) {
+                runner.saveStatus();
+            }
             session.newState(ERROR);
             logger.error("Bad runner at startup {} {}", packet, session);
             ErrorPacket errorPacket = new ErrorPacket(code.mesg,

--- a/src/main/java/org/waarp/openr66/protocol/localhandler/packet/json/RequestJsonPacket.java
+++ b/src/main/java/org/waarp/openr66/protocol/localhandler/packet/json/RequestJsonPacket.java
@@ -32,6 +32,7 @@ public class RequestJsonPacket extends JsonPacket {
 
     protected String filename;
     protected long filesize = -1;
+    protected String fileInfo;
 
     /**
      * @return the filename
@@ -61,6 +62,20 @@ public class RequestJsonPacket extends JsonPacket {
      */
     public void setFilesize(long filesize) {
         this.filesize = filesize;
+    }
+
+    /**
+     * @return the fileInfo
+     */
+    public String getFileInfo() {
+        return fileInfo;
+    }
+
+    /**
+     * @param fileInfo the fileInfo to set
+     */
+    public void setFileInfo(String fileInfo) {
+        this.fileInfo = fileInfo;
     }
 
     public void setRequestUserPacket() {

--- a/src/main/java/org/waarp/openr66/protocol/networkhandler/NetworkServerHandler.java
+++ b/src/main/java/org/waarp/openr66/protocol/networkhandler/NetworkServerHandler.java
@@ -350,6 +350,15 @@ public class NetworkServerHandler extends SimpleChannelInboundHandler<NetworkPac
                 }
             }
         }
+        // check if not already in shutdown or closed
+        if (NetworkTransaction.isShuttingdownNetworkChannel(remoteAddress)
+                || R66ShutdownHook.isShutdownStarting() ||
+                ! localChannelReference.getLocalChannel().isActive()) {
+            logger.debug("Cannot use LocalChannel since already in shutdown: " + packet);
+            // ignore
+            packet.clear();
+            return;
+        }
         ByteBuf buf = packet.getBuffer();
         localChannelReference.getLocalChannel().writeAndFlush(buf);
     }

--- a/src/main/java/org/waarp/openr66/protocol/networkhandler/NetworkTransaction.java
+++ b/src/main/java/org/waarp/openr66/protocol/networkhandler/NetworkTransaction.java
@@ -1158,7 +1158,7 @@ public class NetworkTransaction {
         retrieveRunnerConcurrentHashMap.put(session.getLocalChannelReference().getLocalId(),
                 retrieveRunner);
         retrieveRunner.setDaemon(true);
-        retrieveExecutor.execute(retrieveRunner);
+        Configuration.configuration.getLocalWorkerGroup().execute(retrieveRunner);
     }
 
     /**

--- a/src/main/java/org/waarp/openr66/protocol/utils/R66Versions.java
+++ b/src/main/java/org/waarp/openr66/protocol/utils/R66Versions.java
@@ -20,7 +20,11 @@ public enum R66Versions {
     /**
      * Change VARCHAR(255) to VARCHAR(8096)
      */
-    V2_4_25;
+    V2_4_25,
+    /**
+     * Add support for FileInformation change
+     */
+    V3_0_4;
 
     public String getVersion() {
         return this.name().substring(1).replace('_', '.');


### PR DESCRIPTION
Fix 100% in admin IHM for very small file
Fix TransferTask to allow -copyinfo to copy all previous transfer information to the next one without having to care about the number of information. (applied before any -info)
Add AddUuidJavaTask
Limit the incompatibility of changing FileInformation
Small fix when self-requested transfer require restart
Add AddUuidJavaTask in task/javatask
Add AddDigestJavaTask in task/javatask
Add #UUID# option in AbstractExecutor for Gateway FTP
Fix Static HTTPS service
Check LCR null in restart/Cancel
Check if LCR still active before passing the packet from Network to Local channel
Use LocalWorkerGroup as much as possible