### PR TITLE
Fix compilation with Java 1.8

### DIFF
--- a/src/main/java/org/waarp/openr66/protocol/configuration/PartnerConfiguration.java
+++ b/src/main/java/org/waarp/openr66/protocol/configuration/PartnerConfiguration.java
@@ -29,6 +29,8 @@ import org.waarp.openr66.protocol.utils.Version;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
+import java.util.Map;
+
 /**
  * Partner Configuration
  * 
@@ -358,7 +360,7 @@ public class PartnerConfiguration {
                 + "':"
                 + (Configuration.configuration.getVersions().containsKey(host) ?
                         Configuration.configuration.getVersions().get(host).useJson() : "no:"
-                                + Configuration.configuration.getVersions().keySet()));
+                                + ((Map) Configuration.configuration.getVersions()).keySet()));
         return (Configuration.configuration.getVersions().containsKey(host) && Configuration.configuration.getVersions()
                 .get(host).useJson());
     }


### PR DESCRIPTION
Java 1.8 changed the signature of ConcurrentHashMap.keySet() from

```
Set<K> keySet()
```

to

```
ConcurrentHashMap.KeySetView keySet()
```

When compiled with java 1.8, it breaks Maven's animal-sniffer-plugin,
even cross-compiling with -source 1.7 -target 1.7.

In this case, we were interested in having a Set<String> value,
so casting the ConcurentHashMap object to the Map interface before
calling keyset() solves the compatibility with java 1.7 issues.