### PR TITLE
Fix potential npe

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,6 +148,18 @@
         <artifactId>WaarpFtpClient</artifactId>
         <version>3.0.2</version>
     </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.12</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>2.7.14</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <properties>
   	<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/org/waarp/openr66/protocol/networkhandler/NetworkTransaction.java
+++ b/src/main/java/org/waarp/openr66/protocol/networkhandler/NetworkTransaction.java
@@ -242,17 +242,13 @@ public class NetworkTransaction {
     }
 
     private static final NetworkChannelReference getBlacklistNCR(SocketAddress sa) {
-        // if (sa == null) {
-        //     return false;
-        // }
-        
         InetAddress address = ((InetSocketAddress) sa).getAddress();
         if (address == null) {
             return null;
         }
 
         return networkChannelBlacklistedOnInetSocketAddressConcurrentHashMap.get(
-                ((InetSocketAddress) sa).getAddress().getHostAddress().hashCode()
+                address.getHostAddress().hashCode()
         );
     }
 

--- a/src/main/java/org/waarp/openr66/protocol/networkhandler/NetworkTransaction.java
+++ b/src/main/java/org/waarp/openr66/protocol/networkhandler/NetworkTransaction.java
@@ -20,6 +20,7 @@ package org.waarp.openr66.protocol.networkhandler;
 import static org.waarp.openr66.context.R66FiniteDualStates.AUTHENTR;
 
 import java.net.ConnectException;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.concurrent.ConcurrentHashMap;
@@ -241,8 +242,18 @@ public class NetworkTransaction {
     }
 
     private static final NetworkChannelReference getBlacklistNCR(SocketAddress sa) {
-        return networkChannelBlacklistedOnInetSocketAddressConcurrentHashMap.get(((InetSocketAddress) sa).getAddress()
-                .getHostAddress().hashCode());
+        // if (sa == null) {
+        //     return false;
+        // }
+        
+        InetAddress address = ((InetSocketAddress) sa).getAddress();
+        if (address == null) {
+            return null;
+        }
+
+        return networkChannelBlacklistedOnInetSocketAddressConcurrentHashMap.get(
+                ((InetSocketAddress) sa).getAddress().getHostAddress().hashCode()
+        );
     }
 
     private static final WaarpLock getChannelLock(SocketAddress socketAddress) {
@@ -788,6 +799,10 @@ public class NetworkTransaction {
             return false;
         }
         SocketAddress address = channel.remoteAddress();
+        if (address == null) {
+            return false;
+        }
+
         NetworkChannelReference networkChannelReference = getBlacklistNCR(address);
         return (networkChannelReference != null);
     }

--- a/src/test/java/org/waarp/openr66/protocol/networkhandler/NetworkTransactionTest.java
+++ b/src/test/java/org/waarp/openr66/protocol/networkhandler/NetworkTransactionTest.java
@@ -1,0 +1,27 @@
+package org.waarp.openr66.protocol.networkhandler;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+import org.junit.Test;
+
+import io.netty.channel.Channel;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+
+public class NetworkTransactionTest {
+
+    @Test
+    public void testisBlacklistedPreventNPE() {
+        Channel chan = mock(Channel.class);
+        when(chan.remoteAddress()).thenReturn(null);
+        NetworkTransaction.isBlacklisted(chan);
+
+        reset(chan);
+
+        InetSocketAddress addr = new InetSocketAddress("cannotberesolved", 6666);
+        assertNull(addr.getAddress());
+        doReturn(addr).when(chan).remoteAddress();
+        NetworkTransaction.isBlacklisted(chan);
+    }
+}


### PR DESCRIPTION
Adds safeguards to avoid potential 2 NPE errors with two methods that can return null.