### PR TITLE
Removes a stacktrace from a warn-level log entry

### DIFF
--- a/src/main/java/org/waarp/openr66/context/authentication/R66Auth.java
+++ b/src/main/java/org/waarp/openr66/context/authentication/R66Auth.java
@@ -224,7 +224,7 @@ public class R66Auth extends FilesystemBasedAuthImpl {
         try {
             auth = new DbHostAuth(dbSession, server);
         } catch (WaarpDatabaseException e) {
-            logger.warn("Cannot find the authentication {}", server, e);
+            logger.warn("Cannot find the authentication {}", server);
             return null;
         }
         return auth;


### PR DESCRIPTION
It can be confused with an error