### PR TITLE
Explicitely send an adequate error if an unsupported  HTTP method is used in login

### DIFF
--- a/src/main/java/org/waarp/openr66/protocol/http/adminssl/HttpResponsiveSslHandler.java
+++ b/src/main/java/org/waarp/openr66/protocol/http/adminssl/HttpResponsiveSslHandler.java
@@ -1954,6 +1954,9 @@ public class HttpResponsiveSslHandler extends SimpleChannelInboundHandler<FullHt
                 writeResponse(ctx);
                 return;
             }
+        } else {
+            sendError(ctx, HttpResponseStatus.METHOD_NOT_ALLOWED);
+            return;
         }
         boolean getMenu = false;
         if (params.containsKey("Logon")) {


### PR DESCRIPTION
It also prevents an NPE in some cases

Previous response was a 400 bad request caused by the NPE