### PR TITLE
Set a default value for fileinfo in SpooledDirectory conf

### DIFF
--- a/src/main/java/org/waarp/openr66/client/SpooledDirectoryTransfer.java
+++ b/src/main/java/org/waarp/openr66/client/SpooledDirectoryTransfer.java
@@ -648,7 +648,7 @@ public class SpooledDirectoryTransfer implements Runnable {
         protected List<String> rhosts = new ArrayList<String>();
         protected List<String> localDirectory = new ArrayList<String>();
         protected String rule = null;
-        protected String fileInfo = null;
+        protected String fileInfo = NO_INFO_ARGS;
         protected boolean ismd5 = false;
         protected int block = 0x10000; // 64K as default
         protected String statusfile = null;


### PR DESCRIPTION
Without it, and when fileinfo is not provided on command line or in the XML
config file, database insertions violate the NOT NULL constraint on the database
column