### PR TITLE
Increase the number of LocalWorker threads

### DIFF
--- a/src/main/java/org/waarp/openr66/protocol/configuration/Configuration.java
+++ b/src/main/java/org/waarp/openr66/protocol/configuration/Configuration.java
@@ -655,7 +655,7 @@ public class Configuration {
         handlerGroup = new NioEventLoopGroup(getCLIENT_THREAD(), new WaarpThreadFactory("Handler"));
         subTaskGroup = new NioEventLoopGroup(getCLIENT_THREAD(), new WaarpThreadFactory("SubTask"));
         localBossGroup = new NioEventLoopGroup(getCLIENT_THREAD(), new WaarpThreadFactory("LocalBoss"));
-        localWorkerGroup = new NioEventLoopGroup(getCLIENT_THREAD(), new WaarpThreadFactory("LocalWorker"));
+        localWorkerGroup = new NioEventLoopGroup(3*getCLIENT_THREAD(), new WaarpThreadFactory("LocalWorker"));
         localTransaction = new LocalTransaction();
         WaarpLoggerFactory.setDefaultFactory(WaarpLoggerFactory.getDefaultFactory());
         if (isWarnOnStartup()) {


### PR DESCRIPTION
A transfer needs more than 1 Localworker thread. When the limit number of
possible concurrent transfers is reached, it drives to a deadlock situation
where transfer cannot finish because the Localworker pool is exhausted.