### PR TITLE
handle spaces in EXEC{,MOVE,OUTPUT} tasks commands

### DIFF
--- a/src/main/java/org/waarp/openr66/context/task/AbstractExecTask.java
+++ b/src/main/java/org/waarp/openr66/context/task/AbstractExecTask.java
@@ -1,0 +1,294 @@
+/**
+ * This file is part of Waarp Project.
+ * 
+ * Copyright 2009, Frederic Bregier, and individual contributors by the @author tags. See the
+ * COPYRIGHT.txt in the distribution for a full listing of individual contributors.
+ * 
+ * All Waarp Project is free software: you can redistribute it and/or modify it under the terms of
+ * the GNU General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ * 
+ * Waarp is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with Waarp . If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+package org.waarp.openr66.context.task;
+
+import java.io.File;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.commons.exec.CommandLine;
+
+import org.waarp.common.command.exception.CommandAbstractException;
+import org.waarp.common.logging.WaarpLogger;
+import org.waarp.common.logging.WaarpLoggerFactory;
+import org.waarp.openr66.context.ErrorCode;
+import org.waarp.openr66.context.R66Result;
+import org.waarp.openr66.context.R66Session;
+import org.waarp.openr66.context.filesystem.R66Dir;
+import org.waarp.openr66.context.filesystem.R66File;
+import org.waarp.openr66.database.data.DbTaskRunner;
+import org.waarp.openr66.protocol.configuration.Configuration;
+import org.waarp.openr66.protocol.exception.OpenR66ProtocolNoSslException;
+
+/**
+ * Execute an external command
+ *
+ * It provides some common functionnalities.
+ * 
+ * 
+ * @author Bruno Carlin
+ * 
+ */
+public abstract class AbstractExecTask extends AbstractTask {
+    /**
+     * Internal Logger
+     */
+    private static final WaarpLogger logger = WaarpLoggerFactory
+            .getLogger(AbstractExecTask.class);
+
+    /**
+     * Constructor
+     * 
+     * @param type
+     * @param delay
+     * @param arg
+     * @param session
+     */
+    AbstractExecTask(TaskType type, int delay, String argRule, String argTransfer,
+            R66Session session) {
+        super(type, delay, argRule, argTransfer, session);
+    }
+
+    /**
+     * Apply transferInfo substitutions
+     *
+     * @param line the line to format
+     * @return the line after substitutions
+     */
+    protected String applyTransferSubstitutions(String line) {
+        Object[] argFormat = argTransfer.split(" ");
+        if (argFormat != null && argFormat.length > 0) {
+            try {
+                return String.format(line, argFormat);
+            } catch (Exception e) {
+                // ignored error since bad argument in static rule info
+                logger.error("Bad format in Rule: {"+line+"} " + e.getMessage());
+            }
+        }
+        return line;
+    }
+
+    /**
+     * Generates a Command line object from rule and transfer data
+     *
+     * @param line the command  to process as a string
+     */
+    protected CommandLine buildCommandLine(String line) {
+        String executable = CommandLine.parse(line).getExecutable();
+        String arguments = line.replace(executable, "");
+        File exec = new File(executable);
+        if (exec.isAbsolute()) {
+            if (!exec.canExecute()) {
+                logger.error("Exec command is not executable: " + line);
+                R66Result result = new R66Result(session, false,
+                        ErrorCode.CommandNotFound, session.getRunner());
+                futureCompletion.setResult(result);
+                futureCompletion.cancel();
+                return null;
+            }
+        }
+
+        if (arguments.contains(NOWAIT)) {
+            waitForValidation = false;
+        }
+        if (arguments.contains(LOCALEXEC)) {
+            useLocalExec = true;
+        }
+
+        arguments = arguments.replaceAll("#([A-Z]+)#", "\\${$1}");
+
+        CommandLine commandLine = new CommandLine(exec);
+        commandLine.setSubstitutionMap(getSubstitutionMap());
+        commandLine.addArguments(arguments, false);
+        return commandLine;
+    }
+
+    /**
+     * Generates a substitution map as expected by Apache Commons Exec 
+     * CommandLine
+     */
+    protected Map<String, Object> getSubstitutionMap() {
+        Map<String, Object> rv = new HashMap<String, Object>();
+        rv.put(NOWAIT.replace("#", ""), "");
+        rv.put(LOCALEXEC.replace("#", ""), "");
+
+        File trueFile = null;
+        if (session.getFile() != null) {
+            trueFile = session.getFile().getTrueFile();
+        }
+        if (trueFile != null) {
+            rv.put(TRUEFULLPATH.replace("#", ""), trueFile.getAbsolutePath());
+            rv.put(TRUEFILENAME.replace("#", ""), R66Dir.getFinalUniqueFilename(session.getFile()));
+            rv.put(FILESIZE.replace("#", ""), Long.toString(trueFile.length()));
+        } else {
+            rv.put(TRUEFULLPATH.replace("#", ""), "nofile");
+            rv.put(TRUEFILENAME.replace("#", ""), "nofile");
+            rv.put(FILESIZE.replace("#", ""), "0");
+        }
+
+        DbTaskRunner runner = session.getRunner();
+        if (runner != null) {
+            rv.put(ORIGINALFULLPATH.replace("#", ""), runner.getOriginalFilename());
+            rv.put(ORIGINALFILENAME.replace("#", ""),
+                    R66File.getBasename(runner.getOriginalFilename()));
+            rv.put(RULE.replace("#", ""), runner.getRuleId());
+        }
+
+        DateFormat dateFormat = new SimpleDateFormat("yyyyMMdd");
+        Date date = new Date();
+        rv.put(DATE.replace("#", ""), dateFormat.format(date));
+        dateFormat = new SimpleDateFormat("HHmmss");
+        rv.put(HOUR.replace("#", ""), dateFormat.format(date));
+
+        if (session.getAuth() != null) {
+            rv.put(REMOTEHOST.replace("#", ""), session.getAuth().getUser());
+            String localhost = "";
+            try {
+                localhost = Configuration.configuration.getHostId(session.getAuth().isSsl());
+            } catch (OpenR66ProtocolNoSslException e) {
+                // replace by standard name
+                localhost = Configuration.configuration.getHOST_ID();
+            }
+            rv.put(LOCALHOST.replace("#", ""), localhost);
+        }
+        if (session.getRemoteAddress() != null) {
+            rv.put(REMOTEHOSTADDR.replace("#", ""), session.getRemoteAddress()
+                    .toString());
+            rv.put(LOCALHOSTADDR.replace("#", ""), session.getLocalAddress()
+                    .toString());
+        } else {
+            rv.put(REMOTEHOSTADDR.replace("#", ""), "unknown");
+            rv.put(LOCALHOSTADDR.replace("#", ""), "unknown");
+        }
+        if (runner != null) {
+            rv.put(TRANSFERID.replace("#", ""), runner.getSpecialId());
+            rv.put(REQUESTERHOST.replace("#", ""), runner.getRequester());
+            rv.put(REQUESTEDHOST.replace("#", ""), runner.getRequested());
+            rv.put(FULLTRANSFERID.replace("#", ""), runner.getSpecialId() + "_" 
+                    + runner.getRequester() + "_" + runner.getRequested());
+            rv.put(RANKTRANSFER.replace("#", ""), Integer.toString(runner.getRank()));
+        }
+        rv.put(BLOCKSIZE.replace("#", ""), session .getBlockSize());
+
+        R66Dir dir = new R66Dir(session);
+        if (runner != null) {
+            if (runner.isRecvThrough() || runner.isSendThrough()) {
+                try {
+                    dir.changeDirectoryNotChecked(runner.getRule().getRecvPath());
+                    rv.put(INPATH.replace("#", ""), dir.getFullPath());
+                } catch (CommandAbstractException e) {
+                }
+                dir = new R66Dir(session);
+                try {
+                    dir.changeDirectoryNotChecked(runner.getRule().getSendPath());
+                    rv.put(OUTPATH.replace("#", ""), dir.getFullPath());
+                } catch (CommandAbstractException e) {
+                }
+                dir = new R66Dir(session);
+                try {
+                    dir.changeDirectoryNotChecked(runner.getRule().getWorkPath());
+                    rv.put(WORKPATH.replace("#", ""), dir.getFullPath());
+                } catch (CommandAbstractException e) {
+                }
+                dir = new R66Dir(session);
+                try {
+                    dir.changeDirectoryNotChecked(runner.getRule().getArchivePath());
+                    rv.put(ARCHPATH.replace("#", ""), dir.getFullPath());
+                } catch (CommandAbstractException e) {
+                }
+            } else {
+                try {
+                    dir.changeDirectory(runner.getRule().getRecvPath());
+                    rv.put(INPATH.replace("#", ""), dir.getFullPath());
+                } catch (CommandAbstractException e) {
+                }
+                dir = new R66Dir(session);
+                try {
+                    dir.changeDirectory(runner.getRule().getSendPath());
+                    rv.put(OUTPATH.replace("#", ""), dir.getFullPath());
+                } catch (CommandAbstractException e) {
+                }
+                dir = new R66Dir(session);
+                try {
+                    dir.changeDirectory(runner.getRule().getWorkPath());
+                    rv.put(WORKPATH.replace("#", ""), dir.getFullPath());
+                } catch (CommandAbstractException e) {
+                }
+                dir = new R66Dir(session);
+                try {
+                    dir.changeDirectory(runner.getRule().getArchivePath());
+                    rv.put(ARCHPATH.replace("#", ""), dir.getFullPath());
+                } catch (CommandAbstractException e) {
+                }
+            }
+        } else {
+            try {
+                dir.changeDirectory(Configuration.configuration.getInPath());
+                rv.put(INPATH.replace("#", ""), dir.getFullPath());
+            } catch (CommandAbstractException e) {
+            }
+            dir = new R66Dir(session);
+            try {
+                dir.changeDirectory(Configuration.configuration.getOutPath());
+                rv.put(OUTPATH.replace("#", ""), dir.getFullPath());
+            } catch (CommandAbstractException e) {
+            }
+            dir = new R66Dir(session);
+            try {
+                dir.changeDirectory(Configuration.configuration.getWorkingPath());
+                rv.put(WORKPATH.replace("#", ""), dir.getFullPath());
+            } catch (CommandAbstractException e) {
+            }
+            dir = new R66Dir(session);
+            try {
+                dir.changeDirectory(Configuration.configuration.getArchivePath());
+                rv.put(ARCHPATH.replace("#", ""), dir.getFullPath());
+            } catch (CommandAbstractException e) {
+            }
+        }
+        rv.put(HOMEPATH.replace("#", ""), Configuration.configuration.getBaseDirectory());
+        if (session.getLocalChannelReference() == null) {
+            rv.put(ERRORMSG.replace("#", ""), "NoError");
+            rv.put(ERRORCODE.replace("#", ""), "-");
+            rv.put(ERRORSTRCODE.replace("#", ""), ErrorCode.Unknown.name());
+        } else {
+            try {
+                rv.put(ERRORMSG.replace("#", ""), session.getLocalChannelReference()
+                        .getErrorMessage());
+            } catch (NullPointerException e) {
+                rv.put(ERRORMSG.replace("#", ""), "NoError");
+            }
+            try {
+                rv.put(ERRORCODE.replace("#", ""), session.getLocalChannelReference()
+                        .getCurrentCode().getCode());
+            } catch (NullPointerException e) {
+                rv.put(ERRORCODE.replace("#", ""), "-");
+            }
+            try {
+                rv.put(ERRORSTRCODE.replace("#", ""), session
+                        .getLocalChannelReference().getCurrentCode().name());
+            } catch (NullPointerException e) {
+                rv.put(ERRORSTRCODE.replace("#", ""), ErrorCode.Unknown.name());
+            }
+        }
+        return rv;
+    }
+}

--- a/src/main/java/org/waarp/openr66/context/task/ExecMoveTask.java
+++ b/src/main/java/org/waarp/openr66/context/task/ExecMoveTask.java
@@ -49,7 +49,7 @@ import org.waarp.openr66.protocol.configuration.Configuration;
  * @author Frederic Bregier
  * 
  */
-public class ExecMoveTask extends AbstractTask {
+public class ExecMoveTask extends AbstractExecTask {
     /**
      * Internal Logger
      */
@@ -79,8 +79,8 @@ public class ExecMoveTask extends AbstractTask {
          */
         logger.info("ExecMove with " + argRule + ":" + argTransfer + " and {}",
                 session);
-        String finalname = argRule;
-        finalname = getReplacedValue(finalname, argTransfer.split(" "));
+        String finalname = applyTransferSubstitutions(argRule);
+        
         // Force the WaitForValidation
         waitForValidation = true;
         if (Configuration.configuration.isUseLocalExec() && useLocalExec) {
@@ -94,22 +94,12 @@ public class ExecMoveTask extends AbstractTask {
                 return;
             } // else continue
         }
-        String[] args = finalname.split(" ");
-        File exec = new File(args[0]);
-        if (exec.isAbsolute()) {
-            if (!exec.canExecute()) {
-                logger.error("Exec command is not executable: " + finalname);
-                R66Result result = new R66Result(session, false,
-                        ErrorCode.CommandNotFound, session.getRunner());
-                futureCompletion.setResult(result);
-                futureCompletion.cancel();
-                return;
-            }
+
+        CommandLine commandLine = buildCommandLine(finalname);
+        if (commandLine == null) {
+            return;
         }
-        CommandLine commandLine = new CommandLine(args[0]);
-        for (int i = 1; i < args.length; i++) {
-            commandLine.addArgument(args[i]);
-        }
+
         DefaultExecutor defaultExecutor = new DefaultExecutor();
         PipedInputStream inputStream = new PipedInputStream();
         PipedOutputStream outputStream = null;

--- a/src/main/java/org/waarp/openr66/context/task/ExecOutputTask.java
+++ b/src/main/java/org/waarp/openr66/context/task/ExecOutputTask.java
@@ -52,7 +52,7 @@ import org.waarp.openr66.protocol.configuration.Configuration;
  * @author Frederic Bregier
  * 
  */
-public class ExecOutputTask extends AbstractTask {
+public class ExecOutputTask extends AbstractExecTask {
     /**
      * Internal Logger
      */
@@ -85,8 +85,8 @@ public class ExecOutputTask extends AbstractTask {
          */
         logger.info("ExecOutput with " + argRule + ":" + argTransfer + " and {}",
                 session);
-        String finalname = argRule;
-        finalname = getReplacedValue(finalname, argTransfer.split(" "));
+        String finalname = applyTransferSubstitutions(argRule);
+        //
         // Force the WaitForValidation
         waitForValidation = true;
         if (Configuration.configuration.isUseLocalExec() && useLocalExec) {
@@ -100,22 +100,12 @@ public class ExecOutputTask extends AbstractTask {
                 return;
             } // else continue
         }
-        String[] args = finalname.split(" ");
-        File exec = new File(args[0]);
-        if (exec.isAbsolute()) {
-            if (!exec.canExecute()) {
-                logger.error("Exec command is not executable: " + finalname);
-                R66Result result = new R66Result(session, false,
-                        ErrorCode.CommandNotFound, session.getRunner());
-                futureCompletion.setResult(result);
-                futureCompletion.cancel();
-                return;
-            }
+
+        CommandLine commandLine = buildCommandLine(finalname);
+        if (commandLine == null) {
+            return;
         }
-        CommandLine commandLine = new CommandLine(args[0]);
-        for (int i = 1; i < args.length; i++) {
-            commandLine.addArgument(args[i]);
-        }
+
         DefaultExecutor defaultExecutor = new DefaultExecutor();
         PipedInputStream inputStream = new PipedInputStream();
         PipedOutputStream outputStream = null;


### PR DESCRIPTION
It is done by using a command line parser instead of just splitting the command
line on space characters.

It also removes the risks of empty arguments when there are multiple spaces on
in the command.