### PR TITLE
Feat/speed negociation

### DIFF
--- a/src/main/java/org/waarp/openr66/commander/ClientRunner.java
+++ b/src/main/java/org/waarp/openr66/commander/ClientRunner.java
@@ -548,6 +548,8 @@ public class ClientRunner extends Thread {
                             taskRunner.getRank() + " {}", taskRunner);
         }
         RequestPacket request = taskRunner.getRequest();
+        request.setLimit(localChannelReference.getChannelLimit(
+                    taskRunner.isSender()));
         logger.debug("Will send request {} {}", request, localChannelReference);
         localChannelReference.setClientRunner(this);
         localChannelReference.sessionNewState(R66FiniteDualStates.REQUESTR);

--- a/src/main/java/org/waarp/openr66/protocol/configuration/Configuration.java
+++ b/src/main/java/org/waarp/openr66/protocol/configuration/Configuration.java
@@ -766,9 +766,7 @@ public class Configuration {
         }
 
         // Factory for TrafficShapingHandler
-        globalTrafficShapingHandler = new GlobalTrafficHandler(subTaskGroup, getServerGlobalWriteLimit(),
-                getServerGlobalReadLimit(), getServerChannelWriteLimit(), getServerChannelReadLimit(), getDelayLimit());
-        this.getConstraintLimitHandler().setHandler(globalTrafficShapingHandler);
+        setupLimitHandler();
 
         // Now start the InternalRunner
         internalRunner = new InternalRunner();
@@ -782,6 +780,14 @@ public class Configuration {
         }
     }
 
+    public void setupLimitHandler() {
+        globalTrafficShapingHandler = new GlobalTrafficHandler(subTaskGroup,
+                getServerGlobalWriteLimit(), getServerGlobalReadLimit(),
+                getServerChannelWriteLimit(), getServerChannelReadLimit(),
+                getDelayLimit());
+        this.getConstraintLimitHandler().setHandler(
+                globalTrafficShapingHandler);
+    }
     public void startHttpSupport() {
         // Now start the HTTP support
         logger.info(Messages.getString("Configuration.HTTPStart") + getSERVER_HTTPPORT() + //$NON-NLS-1$

--- a/src/main/java/org/waarp/openr66/protocol/configuration/Configuration.java
+++ b/src/main/java/org/waarp/openr66/protocol/configuration/Configuration.java
@@ -1080,11 +1080,12 @@ public class Configuration {
         this.setServerChannelReadLimit(readSessionLimit);
         this.setServerChannelWriteLimit(writeSessionLimit);
         this.setDelayLimit(delayLimit);
-
-        globalTrafficShapingHandler.configure(writeGlobalLimit, readGlobalLimit,
-                delayLimit);
-        logger.info(Messages.getString("Configuration.BandwidthChange"),
-                globalTrafficShapingHandler);
+	if (globalTrafficShapingHandler != null) {
+        	globalTrafficShapingHandler.configure(writeGlobalLimit, readGlobalLimit,
+                	delayLimit);
+        	logger.info(Messages.getString("Configuration.BandwidthChange"),
+                	globalTrafficShapingHandler);
+	}
     }
 
     /**

--- a/src/main/java/org/waarp/openr66/protocol/localhandler/LocalChannelReference.java
+++ b/src/main/java/org/waarp/openr66/protocol/localhandler/LocalChannelReference.java
@@ -609,31 +609,29 @@ public class LocalChannelReference {
     }
 
     public void setChannelLimit(boolean isSender, long limit) {
-        GlobalChannelTrafficShapingHandler limitHandler =
-            (GlobalChannelTrafficShapingHandler) networkChannelRef.channel()
-                .pipeline().get("LIMIT");
+        ChannelTrafficShapingHandler limitHandler =
+            (ChannelTrafficShapingHandler) networkChannelRef.channel()
+                .pipeline().get("CHANNELLIMIT");
         if (isSender) {
-            limitHandler.setWriteChannelLimit(limit);
-            logger.info("Will write at {} bytes/sec", limit);
+            limitHandler.setWriteLimit(limit);
+            logger.info("Will write at {} Bytes/sec", limit);
         } else {
-            limitHandler.setReadChannelLimit(limit);
-            logger.info("Will read at {} bytes/sec", limit);
+            limitHandler.setReadLimit(limit);
+            logger.info("Will read at {} Bytes/sec", limit);
         }
     }
 
     public long getChannelLimit(boolean isSender) {
-        GlobalChannelTrafficShapingHandler limitHandler =
-            (GlobalChannelTrafficShapingHandler) networkChannelRef.channel()
-                .pipeline().get("LIMIT");
-        if (!isSender) {
-            long global = limitHandler.getReadLimit();
-            long channel = limitHandler.getReadChannelLimit();
-            return getMinLimit(global, channel);
+        long global = 0;
+        long channel = 0;
+        if (isSender) {
+            global = Configuration.configuration.getServerGlobalWriteLimit();
+            channel = Configuration.configuration.getServerChannelWriteLimit();
         } else {
-            long global = limitHandler.getWriteLimit();
-            long channel = limitHandler.getWriteChannelLimit();
-            return getMinLimit(global, channel);
+            global = Configuration.configuration.getServerGlobalReadLimit();
+            channel = Configuration.configuration.getServerChannelReadLimit();
         }
+        return getMinLimit(global, channel);
     }
 
     @Override

--- a/src/main/java/org/waarp/openr66/protocol/localhandler/packet/RequestPacket.java
+++ b/src/main/java/org/waarp/openr66/protocol/localhandler/packet/RequestPacket.java
@@ -331,7 +331,7 @@ public class RequestPacket extends AbstractLocalPacket {
             String fileInformation, char code, long originalSize, long limit,
             String separator) {
         this(rulename, mode, filename, blocksize, rank, specialId,
-                REQVALIDATE, fileInformation, code, originalSize, separator);
+                valid, fileInformation, code, originalSize, separator);
         this.limit = limit;
     }
 
@@ -377,9 +377,7 @@ public class RequestPacket extends AbstractLocalPacket {
             JsonHandler.setValue(node, FIELDS.code, code);
             JsonHandler.setValue(node, FIELDS.length, originalSize);
             // Add limit if specified
-            if (limit != 0) {
-                JsonHandler.setValue(node, FIELDS.limit, limit);
-            }
+            JsonHandler.setValue(node, FIELDS.limit, limit);
             middle = Unpooled.wrappedBuffer(away, JsonHandler.writeAsString(node).getBytes());
         } else {
             middle = Unpooled.wrappedBuffer(away, filename.getBytes(),
@@ -402,7 +400,8 @@ public class RequestPacket extends AbstractLocalPacket {
     public String toString() {
         return "RequestPacket: " + rulename + " : " + mode + " : " + filename +
                 " : " + fileInformation + " : " + blocksize + " : " + rank +
-                " : " + way + " : " + code + " : " + originalSize;
+                " : " + way + " : " + code + " : " + originalSize +
+                " : " + limit;
     }
 
     /**

--- a/src/main/java/org/waarp/openr66/protocol/networkhandler/NetworkServerInitializer.java
+++ b/src/main/java/org/waarp/openr66/protocol/networkhandler/NetworkServerInitializer.java
@@ -50,22 +50,13 @@ public class NetworkServerInitializer extends ChannelInitializer<SocketChannel> 
     protected void initChannel(SocketChannel ch) throws Exception {
         final ChannelPipeline pipeline = ch.pipeline();
         pipeline.addLast("codec", new NetworkPacketCodec());
-        pipeline.addLast(TIMEOUT, new IdleStateHandler(0, 0, Configuration.configuration.getTIMEOUTCON(),
-                TimeUnit.MILLISECONDS));
-        GlobalTrafficHandler handler = Configuration.configuration.getGlobalTrafficShapingHandler();
-        if (handler != null) {
-            pipeline.addLast(LIMIT, handler);
-        }
-        ChannelTrafficShapingHandler trafficChannel = null;
-        try {
-            trafficChannel = Configuration.configuration.newChannelTrafficShapingHandler();
-            if (trafficChannel != null) {
-                pipeline.addLast(LIMITCHANNEL, trafficChannel);
-            }
-        } catch (OpenR66ProtocolNoDataException e) {
-        }
-        pipeline.addLast(Configuration.configuration.getHandlerGroup(), "handler",
-                new NetworkServerHandler(this.server));
+        pipeline.addLast(TIMEOUT, new IdleStateHandler(0, 0,
+                    Configuration.configuration.getTIMEOUTCON(),
+                    TimeUnit.MILLISECONDS));
+        pipeline.addLast(LIMIT,
+                Configuration.configuration.getGlobalTrafficShapingHandler());
+        pipeline.addLast(Configuration.configuration.getHandlerGroup(),
+                "handler", new NetworkServerHandler(this.server));
     }
 
 }

--- a/src/main/java/org/waarp/openr66/protocol/networkhandler/NetworkServerInitializer.java
+++ b/src/main/java/org/waarp/openr66/protocol/networkhandler/NetworkServerInitializer.java
@@ -37,8 +37,8 @@ import org.waarp.openr66.protocol.networkhandler.packet.NetworkPacketCodec;
 public class NetworkServerInitializer extends ChannelInitializer<SocketChannel> {
     public static final String TIMEOUT = "timeout";
     public static final String READTIMEOUT = "readTimeout";
-    public static final String LIMIT = "LIMIT";
-    public static final String LIMITCHANNEL = "LIMITCHANNEL";
+    public static final String LIMITGLOBAL = "GLOBALLIMIT";
+    public static final String LIMITCHANNEL = "CHANNELLIMIT";
 
     protected boolean server = false;
 
@@ -49,12 +49,19 @@ public class NetworkServerInitializer extends ChannelInitializer<SocketChannel> 
     @Override
     protected void initChannel(SocketChannel ch) throws Exception {
         final ChannelPipeline pipeline = ch.pipeline();
-        pipeline.addLast("codec", new NetworkPacketCodec());
         pipeline.addLast(TIMEOUT, new IdleStateHandler(0, 0,
                     Configuration.configuration.getTIMEOUTCON(),
                     TimeUnit.MILLISECONDS));
-        pipeline.addLast(LIMIT,
+        // Global limitation
+        pipeline.addLast(LIMITGLOBAL,
                 Configuration.configuration.getGlobalTrafficShapingHandler());
+        // Per channel limitation
+        pipeline.addLast(LIMITCHANNEL,
+                new ChannelTrafficShapingHandler(
+                    Configuration.configuration.getServerChannelWriteLimit(),
+                    Configuration.configuration.getServerChannelReadLimit(),
+                    Configuration.configuration.getDelayLimit()));
+        pipeline.addLast("codec", new NetworkPacketCodec());
         pipeline.addLast(Configuration.configuration.getHandlerGroup(),
                 "handler", new NetworkServerHandler(this.server));
     }

--- a/src/main/java/org/waarp/openr66/protocol/networkhandler/NetworkTransaction.java
+++ b/src/main/java/org/waarp/openr66/protocol/networkhandler/NetworkTransaction.java
@@ -145,6 +145,7 @@ public class NetworkTransaction {
         WaarpNettyUtil.setBootstrap(clientBootstrap, Configuration.configuration.getNetworkWorkerGroup(),
                 (int) Configuration.configuration.getTIMEOUTCON());
         clientBootstrap.handler(networkServerInitializer);
+        Configuration.configuration.setupLimitHandler();
         clientSslBootstrap = new Bootstrap();
         if (Configuration.configuration.isUseSSL() && Configuration.configuration.getHOST_SSLID() != null) {
             NetworkSslServerInitializer networkSslServerInitializer = new NetworkSslServerInitializer(true);

--- a/src/main/java/org/waarp/openr66/protocol/networkhandler/ssl/NetworkSslServerInitializer.java
+++ b/src/main/java/org/waarp/openr66/protocol/networkhandler/ssl/NetworkSslServerInitializer.java
@@ -72,22 +72,13 @@ public class NetworkSslServerInitializer extends ChannelInitializer<SocketChanne
 
         pipeline.addLast("codec", new NetworkPacketCodec());
         pipeline.addLast(NetworkServerInitializer.TIMEOUT,
-                new IdleStateHandler(0, 0, Configuration.configuration.getTIMEOUTCON(), TimeUnit.MILLISECONDS));
-        GlobalTrafficHandler handler = Configuration.configuration
-                .getGlobalTrafficShapingHandler();
-        if (handler != null) {
-            pipeline.addLast(NetworkServerInitializer.LIMIT, handler);
-        }
-        ChannelTrafficShapingHandler trafficChannel = null;
-        try {
-            trafficChannel =
-                    Configuration.configuration
-                            .newChannelTrafficShapingHandler();
-            pipeline.addLast(NetworkServerInitializer.LIMITCHANNEL, trafficChannel);
-        } catch (OpenR66ProtocolNoDataException e) {
-        }
-        pipeline.addLast(Configuration.configuration.getHandlerGroup(), "handler", new NetworkSslServerHandler(
-                !this.isClient));
+                new IdleStateHandler(0, 0,
+                    Configuration.configuration.getTIMEOUTCON(),
+                    TimeUnit.MILLISECONDS));
+        pipeline.addLast(NetworkServerInitializer.LIMIT,
+                Configuration.configuration.getGlobalTrafficShapingHandler());
+        pipeline.addLast(Configuration.configuration.getHandlerGroup(),
+                "handler", new NetworkSslServerHandler(!this.isClient));
     }
 
     /**

--- a/src/main/java/org/waarp/openr66/protocol/networkhandler/ssl/NetworkSslServerInitializer.java
+++ b/src/main/java/org/waarp/openr66/protocol/networkhandler/ssl/NetworkSslServerInitializer.java
@@ -70,13 +70,22 @@ public class NetworkSslServerInitializer extends ChannelInitializer<SocketChanne
         }
         pipeline.addLast("ssl", sslHandler);
 
-        pipeline.addLast("codec", new NetworkPacketCodec());
         pipeline.addLast(NetworkServerInitializer.TIMEOUT,
                 new IdleStateHandler(0, 0,
                     Configuration.configuration.getTIMEOUTCON(),
                     TimeUnit.MILLISECONDS));
-        pipeline.addLast(NetworkServerInitializer.LIMIT,
+
+        // Global limitation
+        pipeline.addLast(NetworkServerInitializer.LIMITGLOBAL,
                 Configuration.configuration.getGlobalTrafficShapingHandler());
+        // Per channel limitation
+        pipeline.addLast(NetworkServerInitializer.LIMITCHANNEL,
+                new ChannelTrafficShapingHandler(
+                    Configuration.configuration.getServerChannelWriteLimit(),
+                    Configuration.configuration.getServerChannelReadLimit(),
+                    Configuration.configuration.getDelayLimit()));
+ 
+        pipeline.addLast("codec", new NetworkPacketCodec());
         pipeline.addLast(Configuration.configuration.getHandlerGroup(),
                 "handler", new NetworkSslServerHandler(!this.isClient));
     }

--- a/src/main/java/org/waarp/openr66/protocol/utils/ChannelUtils.java
+++ b/src/main/java/org/waarp/openr66/protocol/utils/ChannelUtils.java
@@ -337,17 +337,14 @@ public class ChannelUtils extends Thread {
             }
         }
         if (Configuration.configuration.getServerGlobalWriteLimit() > 0) {
-            GlobalTrafficHandler gts = Configuration.configuration
-                    .getGlobalTrafficShapingHandler();
-            if (gts != null) {
-                TrafficCounter tc = gts.trafficCounter();
-                if (tc != null) {
-                    long wait = waitTraffic(Configuration.configuration.getServerGlobalWriteLimit(),
-                            tc.currentWrittenBytes() + size,
-                            tc.lastTime(), currentTime);
-                    if (wait > 0) {
-                        return wait;
-                    }
+            TrafficCounter tc = Configuration.configuration
+                .getGlobalTrafficShapingHandler().trafficCounter();
+            if (tc != null) {
+                long wait = waitTraffic(Configuration.configuration.getServerGlobalWriteLimit(),
+                        tc.currentWrittenBytes() + size,
+                        tc.lastTime(), currentTime);
+                if (wait > 0) {
+                    return wait;
                 }
             }
         }


### PR DESCRIPTION
* Add speed limit field in Request Packet
* Modify R66 and R66/SSL pipeline to use standard Netty TrafficShapingHandler instead of Waarp ones.
* Allow limit negotiation in request processing to setup Traffic Shaping in order to avoid channel overflow.