### PR TITLE
fix the command run on windows in exec tasks

### DIFF
--- a/src/main/java/org/waarp/openr66/context/task/AbstractExecTask.java
+++ b/src/main/java/org/waarp/openr66/context/task/AbstractExecTask.java
@@ -92,9 +92,18 @@ public abstract class AbstractExecTask extends AbstractTask {
      * @param line the command  to process as a string
      */
     protected CommandLine buildCommandLine(String line) {
-        String executable = CommandLine.parse(line).getExecutable();
-        String arguments = line.replace(executable, "");
-        File exec = new File(executable);
+        if (line.contains(NOWAIT)) {
+            waitForValidation = false;
+        }
+        if (line.contains(LOCALEXEC)) {
+            useLocalExec = true;
+        }
+
+        String replacedLine = line.replaceAll("#([A-Z]+)#", "\\${$1}");
+
+        CommandLine commandLine = CommandLine.parse(replacedLine, getSubstitutionMap());
+
+        File exec = new File(commandLine.getExecutable());
         if (exec.isAbsolute()) {
             if (!exec.canExecute()) {
                 logger.error("Exec command is not executable: " + line);
@@ -106,18 +115,6 @@ public abstract class AbstractExecTask extends AbstractTask {
             }
         }
 
-        if (arguments.contains(NOWAIT)) {
-            waitForValidation = false;
-        }
-        if (arguments.contains(LOCALEXEC)) {
-            useLocalExec = true;
-        }
-
-        arguments = arguments.replaceAll("#([A-Z]+)#", "\\${$1}");
-
-        CommandLine commandLine = new CommandLine(exec);
-        commandLine.setSubstitutionMap(getSubstitutionMap());
-        commandLine.addArguments(arguments, false);
         return commandLine;
     }
 


### PR DESCRIPTION
In EXEC* tasks on windows, if slashes are used for the executable, the resulted
command executed is:

  EXECUTABLE EXECUTABLE ARGUMENTS

with the first EXECUTABLE having antislashes and the second one slashes.

This patch returns the command to its normal form :

  EXECUTABLE ARGUMENTS