### PR TITLE
Prevent ssl hostids to be used on clear channel and vice versa

### DIFF
--- a/src/main/java/org/waarp/openr66/context/R66Session.java
+++ b/src/main/java/org/waarp/openr66/context/R66Session.java
@@ -183,6 +183,7 @@ public class R66Session implements SessionInterface {
      * 
      * @param stat
      */
+    @Deprecated
     public void setStatus(int stat) {
         StackTraceElement elt = Thread.currentThread().getStackTrace()[2];
         this.status = "(" + elt.getFileName() + ":" + elt.getLineNumber() + "):" + stat;

--- a/src/main/java/org/waarp/openr66/protocol/localhandler/ConnectionActions.java
+++ b/src/main/java/org/waarp/openr66/protocol/localhandler/ConnectionActions.java
@@ -34,6 +34,7 @@ import io.netty.channel.ChannelHandlerContext;
 
 import org.waarp.common.command.exception.Reply421Exception;
 import org.waarp.common.command.exception.Reply530Exception;
+import org.waarp.common.database.exception.WaarpDatabaseException;
 import org.waarp.common.digest.FilesystemBasedDigest;
 import org.waarp.common.logging.WaarpLogger;
 import org.waarp.common.logging.WaarpLoggerFactory;
@@ -322,8 +323,14 @@ public abstract class ConnectionActions {
                             localChannelReference.getNetworkChannel().remoteAddress()
                             + " since " + e1.getMessage(), packet.getHostId());
         }
-        DbHostAuth auth = R66Auth.getServerAuth(localChannelReference.getDbSession(),
-                packet.getHostId());
+
+        DbHostAuth auth = null;
+        try {
+            auth = new DbHostAuth(localChannelReference.getDbSession(),
+                    packet.getHostId());
+        } catch (WaarpDatabaseException e) {
+            logger.warn("Cannot find the authentication " + packet.getHostId(), e);
+        }
         if (auth != null && !auth.isActive()) {
             e1 = new Reply530Exception("Host is Inactive therefore connection is refused");
         }
@@ -357,7 +364,7 @@ public abstract class ConnectionActions {
      * @param packet
      * @throws OpenR66ProtocolPacketException
      */
-    public void authent(Channel channel, AuthentPacket packet)
+    public void authent(Channel channel, AuthentPacket packet, boolean isSsl)
             throws OpenR66ProtocolPacketException {
         if (packet.isToValidate()) {
             session.newState(AUTHENTR);
@@ -387,7 +394,7 @@ public abstract class ConnectionActions {
         }
         try {
             session.getAuth().connection(localChannelReference.getDbSession(),
-                    packet.getHostId(), packet.getKey());
+                    packet.getHostId(), packet.getKey(), isSsl);
         } catch (Reply530Exception e1) {
             refusedConnection(channel, packet, e1);
             session.setStatus(42);

--- a/src/main/java/org/waarp/openr66/protocol/localhandler/LocalServerHandler.java
+++ b/src/main/java/org/waarp/openr66/protocol/localhandler/LocalServerHandler.java
@@ -93,6 +93,8 @@ class LocalServerHandler extends SimpleChannelInboundHandler<AbstractLocalPacket
      */
     private TransferActions serverHandler = new TransferActions();
 
+    private boolean isSsl = false;
+
     @Override
     public void channelInactive(ChannelHandlerContext ctx) throws Exception {
         serverHandler.channelClosed(ctx);
@@ -108,6 +110,7 @@ class LocalServerHandler extends SimpleChannelInboundHandler<AbstractLocalPacket
         // action as requested and answer if necessary
         final AbstractLocalPacket packet = msg;
         if (packet.getType() == LocalPacketFactory.STARTUPPACKET) {
+            isSsl = ((StartupPacket) packet).isFromSsl();
             serverHandler.startup(ctx.channel(), (StartupPacket) packet);
         } else {
             if (serverHandler.getLocalChannelReference() == null) {
@@ -129,7 +132,7 @@ class LocalServerHandler extends SimpleChannelInboundHandler<AbstractLocalPacket
             }
             switch (packet.getType()) {
                 case LocalPacketFactory.AUTHENTPACKET: {
-                    serverHandler.authent(ctx.channel(), (AuthentPacket) packet);
+                    serverHandler.authent(ctx.channel(), (AuthentPacket) packet, isSsl);
                     break;
                 }
                 // Already done case LocalPacketFactory.STARTUPPACKET:

--- a/src/main/java/org/waarp/openr66/protocol/localhandler/LocalTransaction.java
+++ b/src/main/java/org/waarp/openr66/protocol/localhandler/LocalTransaction.java
@@ -243,7 +243,7 @@ public class LocalTransaction {
      * @throws OpenR66ProtocolNoConnectionException
      */
     public LocalChannelReference createNewClient(NetworkChannelReference networkChannelReference,
-            Integer remoteId, R66Future futureRequest)
+            Integer remoteId, R66Future futureRequest, boolean fromSsl)
             throws OpenR66ProtocolSystemException, OpenR66ProtocolRemoteShutdownException,
             OpenR66ProtocolNoConnectionException {
         ChannelFuture channelFuture = null;
@@ -284,7 +284,7 @@ public class LocalTransaction {
                         localChannelReference);
                 logger.info("Add one localChannel to a Network Channel: " + channel.id());
                 // Now send first a Startup message
-                StartupPacket startup = new StartupPacket(localChannelReference.getLocalId());
+                StartupPacket startup = new StartupPacket(localChannelReference.getLocalId(), fromSsl);
                 channel.writeAndFlush(startup);
                 return localChannelReference;
             } else {

--- a/src/main/java/org/waarp/openr66/protocol/localhandler/packet/AbstractLocalPacket.java
+++ b/src/main/java/org/waarp/openr66/protocol/localhandler/packet/AbstractLocalPacket.java
@@ -39,6 +39,8 @@ public abstract class AbstractLocalPacket {
 
     protected ByteBuf end;
 
+    protected boolean fromSSL = false;
+
     public AbstractLocalPacket(ByteBuf header, ByteBuf middle,
             ByteBuf end) {
         this.header = header;

--- a/src/main/java/org/waarp/openr66/protocol/localhandler/packet/StartupPacket.java
+++ b/src/main/java/org/waarp/openr66/protocol/localhandler/packet/StartupPacket.java
@@ -31,6 +31,7 @@ import org.waarp.openr66.protocol.localhandler.LocalChannelReference;
  */
 public class StartupPacket extends AbstractLocalPacket {
     private final Integer localId;
+    private final boolean fromSsl;
 
     /**
      * @param headerLength
@@ -42,14 +43,16 @@ public class StartupPacket extends AbstractLocalPacket {
     public static StartupPacket createFromBuffer(int headerLength,
             int middleLength, int endLength, ByteBuf buf) {
         Integer newId = buf.readInt();
-        return new StartupPacket(newId);
+        Boolean fromSsl = buf.readBoolean();
+        return new StartupPacket(newId, fromSsl);
     }
 
     /**
      * @param newId
      */
-    public StartupPacket(Integer newId) {
+    public StartupPacket(Integer newId, boolean fromSsl) {
         localId = newId;
+        this.fromSsl = fromSsl;
     }
 
     @Override
@@ -65,7 +68,8 @@ public class StartupPacket extends AbstractLocalPacket {
 
     @Override
     public void createMiddle(LocalChannelReference lcr) throws OpenR66ProtocolPacketException {
-        middle = Unpooled.EMPTY_BUFFER;
+        middle = Unpooled.buffer(1);
+        header.writeBoolean(fromSsl);
     }
 
     @Override
@@ -83,6 +87,10 @@ public class StartupPacket extends AbstractLocalPacket {
      */
     public Integer getLocalId() {
         return localId;
+    }
+
+    public boolean isFromSsl() {
+        return fromSsl;
     }
 
 }

--- a/src/main/java/org/waarp/openr66/protocol/networkhandler/NetworkServerHandler.java
+++ b/src/main/java/org/waarp/openr66/protocol/networkhandler/NetworkServerHandler.java
@@ -281,7 +281,7 @@ public class NetworkServerHandler extends SimpleChannelInboundHandler<NetworkPac
             logger.debug("NetworkRecv Create: {} {}", packet,
                     channel.id());
             NetworkTransaction.createConnectionFromNetworkChannelStartup(
-                    this.networkChannelReference, packet);
+                    this.networkChannelReference, packet, isSSL);
             return;
         } else {
             if (packet.getCode() == LocalPacketFactory.ENDREQUESTPACKET) {

--- a/src/main/java/org/waarp/openr66/protocol/networkhandler/NetworkTransaction.java
+++ b/src/main/java/org/waarp/openr66/protocol/networkhandler/NetworkTransaction.java
@@ -374,7 +374,7 @@ public class NetworkTransaction {
             try {
                 localChannelReference = Configuration.configuration
                         .getLocalTransaction().createNewClient(networkChannelReference,
-                                ChannelUtils.NOCHANNEL, futureRequest);
+                                ChannelUtils.NOCHANNEL, futureRequest, isSSL);
             } catch (OpenR66ProtocolSystemException e) {
                 throw new OpenR66ProtocolNetworkException(
                         "Cannot connect to local channel", e);
@@ -507,9 +507,10 @@ public class NetworkTransaction {
      */
     public static void createConnectionFromNetworkChannelStartup(
             NetworkChannelReference networkChannelReference,
-            NetworkPacket packet) {
+            NetworkPacket packet, boolean isSsl) {
         CreateConnectionFromNetworkChannel ccfnc =
-                new CreateConnectionFromNetworkChannel(networkChannelReference, packet);
+                new CreateConnectionFromNetworkChannel(networkChannelReference,
+                        packet, isSsl);
         ccfnc.setDaemon(true);
         Configuration.configuration.getExecutorService().execute(ccfnc);
     }
@@ -517,11 +518,13 @@ public class NetworkTransaction {
     private static class CreateConnectionFromNetworkChannel extends Thread {
         final NetworkChannelReference networkChannelReference;
         final NetworkPacket startupPacket;
+        final boolean fromSsl;
 
         private CreateConnectionFromNetworkChannel(NetworkChannelReference networkChannelReference,
-                NetworkPacket packet) {
+                NetworkPacket packet, boolean fromSsl) {
             this.networkChannelReference = networkChannelReference;
             this.startupPacket = packet;
+            this.fromSsl = fromSsl;
         }
 
         @Override
@@ -532,7 +535,7 @@ public class NetworkTransaction {
             try {
                 lcr = Configuration.configuration
                         .getLocalTransaction().createNewClient(networkChannelReference,
-                                startupPacket.getRemoteId(), null);
+                                startupPacket.getRemoteId(), null, fromSsl);
             } catch (OpenR66ProtocolSystemException e1) {
                 logger.error("Cannot create LocalChannel for: " + startupPacket + " due to "
                         + e1.getMessage());


### PR DESCRIPTION
Correct a security bug which allowed ssl hostids to be authenticated on clear channel.
Tag some methods as deprecated.